### PR TITLE
Use MongoDB instead of TinyDB

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   "matching_results_folder": "/Users/andrewg/Desktop/dcc/results",
   "output_folder": "/Users/andrewg/Desktop/dcc/output",
   "entity_service_url": "http://localhost:8851/api/v1",
-  "matching_threshold": 0.75
+  "matching_threshold": 0.8,
+  "mongo_uri": "localhost:27017"
 }

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -57,3 +57,6 @@ class Configuration:
 
   def projects(self):
     return self.config_json['projects']
+
+  def mongo_uri(self):
+    return self.config_json['mongo_uri']

--- a/linkids.py
+++ b/linkids.py
@@ -1,5 +1,5 @@
 from dcctools.config import Configuration
-from tinydb import TinyDB
+from pymongo import MongoClient
 from dcctools.deconflict import deconflict
 from functools import reduce
 from pathlib import Path
@@ -14,7 +14,8 @@ parser.add_argument('--remove', action="store_true", help='Delete the results.js
 args = parser.parse_args()
 
 c = Configuration("config.json")
-database = TinyDB('results.json')
+client = MongoClient(port=27017)
+database = client.linkage_agent
 
 systems = c.systems()
 header = ['LINK_ID']
@@ -34,7 +35,7 @@ with open(result_csv_path, 'w', newline='') as csvfile:
   writer = csv.DictWriter(csvfile, fieldnames=header)
   writer.writeheader()
 
-  for row in database.all():
+  for row in database.match_groups.find():
     conflict = reduce(lambda acc, s: acc | len(row.get(s, [])) > 1, systems, False)
     final_record = {}
     if conflict:

--- a/linkids.py
+++ b/linkids.py
@@ -14,7 +14,7 @@ parser.add_argument('--remove', action="store_true", help='Delete the results.js
 args = parser.parse_args()
 
 c = Configuration("config.json")
-client = MongoClient(port=27017)
+client = MongoClient(c.mongo_uri())
 database = client.linkage_agent
 
 systems = c.systems()

--- a/match.py
+++ b/match.py
@@ -4,7 +4,7 @@ from pymongo import MongoClient
 from dcctools.anonlink import Results, Project
 
 c = Configuration("config.json")
-client = MongoClient(port=27017)
+client = MongoClient(c.mongo_uri())
 database = client.linkage_agent
 for project_name, schema in c.load_schema().items():
   project = Project(project_name, schema, c.systems(), c.entity_service_url())

--- a/match.py
+++ b/match.py
@@ -1,12 +1,11 @@
 import time
 from dcctools.config import Configuration
-from tinydb import TinyDB
-from tinydb.storages import JSONStorage
-from tinydb.middlewares import CachingMiddleware
+from pymongo import MongoClient
 from dcctools.anonlink import Results, Project
 
 c = Configuration("config.json")
-database = TinyDB('results.json', storage=CachingMiddleware(JSONStorage))
+client = MongoClient(port=27017)
+database = client.linkage_agent
 for project_name, schema in c.load_schema().items():
   project = Project(project_name, schema, c.systems(), c.entity_service_url())
   project.start_project()
@@ -23,6 +22,4 @@ for project_name, schema in c.load_schema().items():
   result_json = project.get_results()
   results = Results(c.systems(), project_name, result_json)
   print(result_json)
-  results.insert_results(database)
-
-database.close()
+  results.insert_results(database.match_groups)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=5.3.2
 requests>=2.20.0
-tinydb>=3.15.2
+pymongo>=3.11.2

--- a/tests/anonlink_test.py
+++ b/tests/anonlink_test.py
@@ -1,109 +1,107 @@
 import pytest
 import os
-from tinydb import TinyDB, Query
+from pymongo import MongoClient
 from dcctools.anonlink import Results
 
 def test_insert_results():
-  db_location = 'tests/test_db.json'
   systems = ['a', 'b', 'c']
   project = 'name-dob'
   anonlink_results = {'groups': [[[0, 1], [1, 2], [2, 3]],
     [[1, 5], [2, 6]],
     [[0, 8], [2, 9]]]}
 
-  if os.path.exists(db_location):
-    os.remove(db_location)
+  client = MongoClient(port=27017)
+  database = client.test
 
-  database = TinyDB(db_location)
+  if "match_results" in database.list_collection_names():
+    database.drop_collection("match_results")
 
+  collection = database.match_results
   r = Results(systems, project, anonlink_results)
-  r.insert_results(database)
+  r.insert_results(collection)
 
-  assert len(database) == 3
+  assert collection.count_documents({}) == 3
 
-  RecordGroup = Query()
+  doc = collection.find_one({'a': 1})
+  assert doc['b'] == [2]
+  assert doc['c'] == [3]
 
-  doc = database.search(RecordGroup['a'].any([1]))
-  assert doc[0]['b'] == [2]
-  assert doc[0]['c'] == [3]
+  doc = collection.find_one({'b': 5})
+  assert doc['c'] == [6]
 
-  doc = database.search(RecordGroup['b'].any([5]))
-  assert doc[0]['c'] == [6]
-
-  doc = database.search(RecordGroup['a'].any([8]))
-  assert doc[0]['c'] == [9]
+  doc = collection.find_one({'a': 8})
+  assert doc['c'] == [9]
 
 def test_insert_conflicting_results_split_group():
-  db_location = 'tests/test_db.json'
   systems = ['a', 'b']
   project1 = 'name-dob'
   anonlink_results1 = {'groups': [[[0, 1], [1, 2]],
     [[0, 8], [1, 9]]]}
 
-  if os.path.exists(db_location):
-    os.remove(db_location)
+  client = MongoClient(port=27017)
+  database = client.test
 
-  database = TinyDB(db_location)
+  if "match_results" in database.list_collection_names():
+    database.drop_collection("match_results")
+
+  collection = database.match_results
 
   r = Results(systems, project1, anonlink_results1)
-  r.insert_results(database)
+  r.insert_results(collection)
 
-  assert len(database) == 2
+  assert collection.count_documents({}) == 2
 
-  RecordGroup = Query()
+  doc = collection.find_one({'a': 1})
+  assert doc['b'] == [2]
 
-  doc = database.search(RecordGroup['a'].any([1]))
-  assert doc[0]['b'] == [2]
-
-  doc = database.search(RecordGroup['b'].any([9]))
-  assert doc[0]['a'] == [8]
+  doc = collection.find_one({'b': 9})
+  assert doc['a'] == [8]
 
   project2 = 'name-sex'
   anonlink_results2 = {'groups': [[[0, 1], [1, 9]],
     [[0, 20], [1, 30]]]}
 
   r = Results(systems, project2, anonlink_results2)
-  r.insert_results(database)
+  r.insert_results(collection)
 
-  assert len(database) == 2
+  assert collection.count_documents({}) == 2
 
-  doc = database.search(RecordGroup['a'].any([1]))
-  assert doc[0]['b'] == [2, 9]
+  doc = collection.find_one({'a': 1})
+  assert doc['b'] == [2, 9]
 
 def test_insert_conflicting_results_same_group():
-  db_location = 'tests/test_db.json'
   systems = ['a', 'b']
   project1 = 'name-dob'
   anonlink_results1 = {'groups': [[[0, 1], [1, 2]],
     [[0, 8], [1, 9]]]}
 
-  if os.path.exists(db_location):
-    os.remove(db_location)
+  client = MongoClient(port=27017)
+  database = client.test
 
-  database = TinyDB(db_location)
+  if "match_results" in database.list_collection_names():
+    database.drop_collection("match_results")
 
+  collection = database.match_results
   r = Results(systems, project1, anonlink_results1)
-  r.insert_results(database)
+  r.insert_results(collection)
 
-  assert len(database) == 2
+  assert collection.count_documents({}) == 2
 
-  RecordGroup = Query()
+  doc = collection.find_one({'a': 1})
+  assert doc['b'] == [2]
 
-  doc = database.search(RecordGroup['a'].any([1]))
-  assert doc[0]['b'] == [2]
-
-  doc = database.search(RecordGroup['b'].any([9]))
-  assert doc[0]['a'] == [8]
+  doc = collection.find_one({'b': 9})
+  assert doc['a'] == [8]
 
   project2 = 'name-sex'
   anonlink_results2 = {'groups': [[[0, 1], [1, 10]],
     [[0, 20], [1, 30]]]}
 
   r = Results(systems, project2, anonlink_results2)
-  r.insert_results(database)
+  r.insert_results(collection)
 
-  assert len(database) == 3
+  assert collection.count_documents({}) == 3
 
-  doc = database.search(RecordGroup['a'].any([1]))
-  assert doc[0]['b'] == [2, 10]
-  assert len(doc[0]['run_results']) == 2
+  doc = collection.find_one({'a': 1})
+  assert doc['b'] == [2, 10]
+  assert len(doc['run_results']) == 2


### PR DESCRIPTION
Replaces TinyDB with MongoDB.
Add a property to the configuration file to specify the connection string for MongoDB. 