### PR TITLE
Script for reviewing impact of removing one project

### DIFF
--- a/project_review.py
+++ b/project_review.py
@@ -12,14 +12,14 @@ c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)
 database = client.linkage_agent
 
-parser = argparse.ArgumentParser(
-    description="Tool for tracing a LINKID back to its matching record in MongoDB"
-)
-parser.add_argument(
-    "linkid",
-    help="The LINKID to find",
-)
-args = parser.parse_args()
+# parser = argparse.ArgumentParser(
+#     description="Tool for tracing a LINKID back to its matching record in MongoDB"
+# )
+# parser.add_argument(
+#     "linkid",
+#     help="The LINKID to find",
+# )
+# args = parser.parse_args()
 
 
 

--- a/project_review.py
+++ b/project_review.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+import time
+import argparse
+import csv
+from pprint import pprint as pp
+
+from pymongo import MongoClient
+
+from dcctools.config import Configuration
+
+c = Configuration("config.json")
+client = MongoClient(c.mongo_uri)
+database = client.linkage_agent
+
+parser = argparse.ArgumentParser(
+    description="Tool for tracing a LINKID back to its matching record in MongoDB"
+)
+parser.add_argument(
+    "linkid",
+    help="The LINKID to find",
+)
+args = parser.parse_args()
+
+
+
+# 2 get some overall analytics. total match pairs, total links
+total = database.match_groups.count_documents({})
+print(f"total number of matches: {total}")
+
+total = database.match_groups.aggregate([{
+    "$group": {
+        "_id": None,
+        "count": {
+            "$sum": {"$size": "$run_results"}
+        }
+    }
+}])
+for doc in total:  # should only be one
+    print(f"total number of matched pairs (run_results): {doc['count']}")
+
+
+# 2. get analytics on how many matches are based on each project
+
+# 3. get analytics on what matches would be different if each project were excluded - numbers, specific examples
+
+for project in c.projects:
+    print(project.upper())
+    query = {"run_results.project": project}
+    count = database.match_groups.count_documents(query)
+    print(f"{count} results have a match on {project}")
+
+    only_this_project = {**query, "run_results": {"$size": 1}}
+    count = database.match_groups.count_documents(only_this_project)
+    print(f"{count} results have a match ONLY on {project}")
+
+    if count:
+        results = database.match_groups.find(only_this_project)
+        for result in results:
+            pp(result)
+
+    # Now find results that would be different if this project were excluded
+    different_results = []
+    results = database.match_groups.find(query)
+    for result in results:
+        if len(result['run_results']) == 1:
+            continue  # we already addressed this above, in the "match ONLY on" section
+
+        # sample result:
+        #  {
+        #   "site_c": [518],
+        #   "site_d": [317],
+        #   "site_e": [732],
+        #   "run_results": [
+        #     {
+        #       "site_c": 518,
+        #       "site_d": 317,
+        #       "project": "name-sex-dob-phone"
+        #     },
+        #     {
+        #       "site_c": 518,
+        #       "site_d": 317,
+        #       "project": "name-sex-dob-zip"
+        #     },
+        #     {
+        #       "site_d": 317,
+        #       "site_e": 732,
+        #       "project": "name-sex-dob-parents"
+        #     },
+        #     {
+        #       "site_d": 518,
+        #       "site_e": 732,
+        #       "project": "name-sex-dob-parents"
+        #     }
+        #   ]
+        # }
+
+        # basically the idea is we need to rebuild the site lists,
+        # but don't include the given project
+        # (it may be possible to do this by mongo aggregation but i hope this is more readable)
+
+        new_result = {}
+
+        for project_result in result['run_results']:
+            if project_result['project'] == project:
+                continue
+
+            for key, value in project_result.items():
+                if key == 'project':
+                    continue
+
+                if key not in new_result:
+                    new_result[key] = set()
+
+                new_result[key].add(value)
+
+        # now compare the old result to the new result, see if anything changed
+        for key, value in result.items():
+            if key in ['run_results', '_id']:
+                continue
+
+            if key not in new_result or set(value) != new_result[key]:
+                different_results.append((result, new_result))
+                break
+
+
+    print(f"number of changes by removing this project: {len(different_results)}")
+    if different_results:
+        pp(different_results)
+
+    print()


### PR DESCRIPTION
This PR adds a new script `project_review.py` that helps in reviewing the impact of removing a single project from the linkage results. The script iterates through all match_groups from the DB that matched using the given program, and re-evaluates which person IDs may be linked if those results were removed. (note: we may want to clean up the nomenclature here as I use "results" way too often)

Command line args:
 -p PROGRAM: optional, specifies a single program to evaluate removal. If not specified the script will loop through all programs listed in config.json
 -l / --linkids: optional, toggles the output format to ONLY display relevant LINKIDs, if not specified then it will print out a little extra detail in the format `LINKID {linkid} links to {sites} only by {project} -- remaining links are {sites}`
 -d/ --debug: optional, enable this to print out the raw objects for debugging purposes


Sample output snippet based on Synthetic Denver:
```
Total number of matches: 1435
Total number of matched pairs (run_results): 5913

NAME-SEX-DOB-PARENTS
1428 results have a match on name-sex-dob-parents
0 results have a match ONLY on name-sex-dob-parents
Total # of changes by removing this project: 7
LINKID 3a965f38-47c6-11ec-a1da-acde48001122 links to site_b only by name-sex-dob-parents -- remaining links are ['site_c', 'site_d']
LINKID 3a96796e-47c6-11ec-a1da-acde48001122 links to site_a only by name-sex-dob-parents -- remaining links are ['site_b', 'site_c', 'site_f']
LINKID 3a968616-47c6-11ec-a1da-acde48001122 links to site_b only by name-sex-dob-parents -- remaining links are ['site_a', 'site_c']
LINKID 3a96ad9e-47c6-11ec-a1da-acde48001122 links to site_e only by name-sex-dob-parents -- remaining links are ['site_a', 'site_d', 'site_f']
LINKID 3a995350-47c6-11ec-a1da-acde48001122 links to site_f only by name-sex-dob-parents -- remaining links are ['site_a', 'site_e']
LINKID 3a9b3ea4-47c6-11ec-a1da-acde48001122 links to site_e only by name-sex-dob-parents -- remaining links are ['site_d', 'site_f']
LINKID 3a9d7b60-47c6-11ec-a1da-acde48001122 links to site_c only by name-sex-dob-parents -- remaining links are ['site_b', 'site_d']

NAME-SEX-DOB-ADDR
1423 results have a match on name-sex-dob-addr
1 results have a match ONLY on name-sex-dob-addr
Total # of changes by removing this project: 2
LINKID 3a9e185e-47c6-11ec-a1da-acde48001122 was created using only name-sex-dob-addr -- sites: ['site_b', 'site_c']
LINKID 3a9ce56a-47c6-11ec-a1da-acde48001122 links to site_c only by name-sex-dob-addr -- remaining links are ['site_b', 'site_f', 'site_a']
```