### PR TITLE
Update review scripts based on most recent feedback

### DIFF
--- a/backtrace.py
+++ b/backtrace.py
@@ -27,10 +27,15 @@ with open(result_csv_path) as csvfile:
     reader = csv.DictReader(csvfile)
     link_id_row = next(filter(lambda r: r['LINK_ID'] == args.linkid, reader))
 
+print(f"Actual linkages for {args.linkid}:")
+
 query = {}
 for (key, value) in link_id_row.items():
     if key != 'LINK_ID' and len(value) > 0:
-      query[key] = int(value)
+        query[key] = int(value)
+        print(f"{key}: {value}")
+
+print('---')
 
 for result in database.match_groups.find(query):
     print(result)


### PR DESCRIPTION
This updates the 2 review scripts based on recent feedback from CO:

1. In backtrace.py, it now prints out the actual linkages that were selected. This is helpful in reviewing "highly-connected" networks, because otherwise the database does not indicate which row from a given site was selected, if there were multiple options.

2. In project_review.py, added a csv export option with the `-c` / `--csv` flag. CSV is written to console, so that users can send it to whatever file they like, ex `python project_review.py -c > demo.csv`. Most of the changes across the file are to not output certain things if the csv option is selected. The CSV has columns based on the current configuration, with 2 + (2 * number of systems) columns: link_id, removed project, and for each system, action and id. Action is "dropped" if removing the given project would drop a link to that system, "retained" if it would not, or blank if there was no link to that system for the given link ID. The ID is the row position for that system associated with the link ID. (Not fully sure if that's useful but it was easy to add)

A sample running against synthetic Denver is attached: 
[demo.csv](https://github.com/mitre/linkage-agent-tools/files/7765235/demo.csv)
