### PR TITLE
Add Black and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+# See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+max-line-length = 88
+extend-ignore = E203
+exclude = venv

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,26 @@
+name: Style
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  style:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+    - name: pip install
+      run: pip install -r requirements.txt
+    - name: run black
+      run: black --check .
+    - name: run flake8
+      run: flake8 .
+    - name: run isort
+      run: isort . -c

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=black
+

--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ following command:
 
 `python -m pytest`
 
+## Formatting and Linting
+
+This repository uses `black`, `flake8`, and `isort` to maintain consistent formatting and style. These tools can be run with the following command:
+
+```shell
+black .
+isort .
+flake8 .
+```
+
 ## [WIP] Jupyter Notebook
 
 The `Linkage and Blocking Tuning Tool` Jupyter notebook is a work in progress

--- a/dcctools/anonlink.py
+++ b/dcctools/anonlink.py
@@ -1,4 +1,3 @@
-import itertools as it
 import json
 import subprocess
 

--- a/dcctools/backtrace.py
+++ b/dcctools/backtrace.py
@@ -25,17 +25,17 @@ result_csv_path = Path(c.matching_results_folder) / "link_ids.csv"
 link_id_row = None
 with open(result_csv_path) as csvfile:
     reader = csv.DictReader(csvfile)
-    link_id_row = next(filter(lambda r: r['LINK_ID'] == args.linkid, reader))
+    link_id_row = next(filter(lambda r: r["LINK_ID"] == args.linkid, reader))
 
 print(f"Actual linkages for {args.linkid}:")
 
 query = {}
 for (key, value) in link_id_row.items():
-    if key != 'LINK_ID' and len(value) > 0:
+    if key != "LINK_ID" and len(value) > 0:
         query[key] = int(value)
         print(f"{key}: {value}")
 
-print('---')
+print("---")
 
 for result in database.match_groups.find(query):
     print(result)

--- a/dcctools/backtrace.py
+++ b/dcctools/backtrace.py
@@ -1,11 +1,10 @@
-from pathlib import Path
-import time
 import argparse
 import csv
-
-from pymongo import MongoClient
+import time
+from pathlib import Path
 
 from config import Configuration
+from pymongo import MongoClient
 
 c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)

--- a/dcctools/backtrace.py
+++ b/dcctools/backtrace.py
@@ -1,6 +1,5 @@
 import argparse
 import csv
-import time
 from pathlib import Path
 
 from config import Configuration

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -22,14 +22,21 @@ class Configuration:
 
     def validate_config(self):
         config_issues = []
-        if self.config_json["household_match"] and "household_threshold" not in self.config_json.keys():
-            config_issues.append("config file specifies household match without float household matching threshold")
+        if (
+            self.config_json["household_match"]
+            and "household_threshold" not in self.config_json.keys()
+        ):
+            config_issues.append(
+                "config file specifies household match without float household matching threshold"
+            )
         elif type(self.config_json["matching_threshold"]) == list:
             proj_len = len(self.config_json["projects"])
             thresh_len = len(self.config_json["matching_threshold"])
             if proj_len != thresh_len:
-                config_issues.append(f"Number of projects ({proj_len}) and thresholds ({thresh_len}) is unequal \
-                \n\tThreshold must either be float or list of floats equal in length to the number of projects")
+                config_issues.append(
+                    f"Number of projects ({proj_len}) and thresholds ({thresh_len}) is unequal \
+                \n\tThreshold must either be float or list of floats equal in length to the number of projects"
+                )
         return config_issues
 
     def validate_all_present(self):
@@ -175,14 +182,17 @@ class Configuration:
         return house_mapping
 
     def get_project_threshold(self, project_name):
-        config_threshold = self.household_threshold if self.household_match else self.matching_threshold
+        config_threshold = (
+            self.household_threshold
+            if self.household_match
+            else self.matching_threshold
+        )
         if type(config_threshold) == list:
             project_index = config_threshold.index(project_name)
             threshold = config_threshold[project_index]
         else:
             threshold = config_threshold
         return threshold
-
 
     @property
     def matching_threshold(self):

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -27,15 +27,17 @@ class Configuration:
             and "household_threshold" not in self.config_json.keys()
         ):
             config_issues.append(
-                "config file specifies household match without float household matching threshold"
+                "config file specifies household match without \
+                        float household matching threshold"
             )
         elif type(self.config_json["matching_threshold"]) == list:
             proj_len = len(self.config_json["projects"])
             thresh_len = len(self.config_json["matching_threshold"])
             if proj_len != thresh_len:
                 config_issues.append(
-                    f"Number of projects ({proj_len}) and thresholds ({thresh_len}) is unequal \
-                \n\tThreshold must either be float or list of floats equal in length to the number of projects"
+                    f"Number of projects ({proj_len}) and thresholds ({thresh_len}) \
+                            is unequal \n\tThreshold must either be float or list of \
+                            floats equal in length to the number of projects"
                 )
         return config_issues
 
@@ -176,7 +178,7 @@ class Configuration:
                     try:
                         # Map the household pos to the list key = individual pos
                         house_mapping[individual_id] = int(line[0])
-                    except:
+                    except Exception:
                         e = sys.exc_info()[0]
                         print(e)
         return house_mapping

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -1,8 +1,8 @@
 import csv
 import json
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 from zipfile import ZipFile
 
 

--- a/dcctools/exact_matches.py
+++ b/dcctools/exact_matches.py
@@ -9,7 +9,9 @@ parser = argparse.ArgumentParser(
                  for one project across sites."
 )
 parser.add_argument(
-    "-p", "--project", default="name-sex-dob-zip",
+    "-p",
+    "--project",
+    default="name-sex-dob-zip",
     help="Select a project to review exact matches across sites. \
           Default: name-sex-dob-zip",
 )
@@ -28,14 +30,16 @@ clks = {}
 for system in c.systems:
     raw_clks = c.get_clks_raw(system, project)
     clk_json = json.loads(raw_clks)
-    clks[system] = set(clk_json['clks'])
+    clks[system] = set(clk_json["clks"])
     print(f"Size of {system}: {len(clks[system])}")
 
 total_exact_matches = set()
 
 for pair in itertools.combinations(c.systems, 2):
     pairwise_matches = clks[pair[0]].intersection(clks[pair[1]])
-    print(f"Total exact matches between {pair[0]} and {pair[1]}: {len(pairwise_matches)}")
+    print(
+        f"Total exact matches between {pair[0]} and {pair[1]}: {len(pairwise_matches)}"
+    )
 
     total_exact_matches.update(pairwise_matches)  # update means add to set
 

--- a/dcctools/freqs_of_matching_projs.py
+++ b/dcctools/freqs_of_matching_projs.py
@@ -1,6 +1,5 @@
-from pymongo import MongoClient
-
 from config import Configuration
+from pymongo import MongoClient
 
 c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)

--- a/dcctools/freqs_of_matching_projs.py
+++ b/dcctools/freqs_of_matching_projs.py
@@ -6,12 +6,16 @@ c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)
 database = client.linkage_agent
 
-results = database.match_groups.aggregate([{
-    '$group': {
-        '_id': {'$size': '$run_results'},
-        'total': {'$sum': 1},
-    }
-}])
+results = database.match_groups.aggregate(
+    [
+        {
+            "$group": {
+                "_id": {"$size": "$run_results"},
+                "total": {"$sum": 1},
+            }
+        }
+    ]
+)
 
 for result in results:
     print(result)

--- a/dcctools/matching_project_shapes.py
+++ b/dcctools/matching_project_shapes.py
@@ -1,6 +1,5 @@
-from pymongo import MongoClient
-
 from config import Configuration
+from pymongo import MongoClient
 
 c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)

--- a/dcctools/project_matching_freq.py
+++ b/dcctools/project_matching_freq.py
@@ -1,6 +1,5 @@
-from pymongo import MongoClient
-
 from config import Configuration
+from pymongo import MongoClient
 
 c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)

--- a/dcctools/project_matching_freq.py
+++ b/dcctools/project_matching_freq.py
@@ -7,17 +7,12 @@ client = MongoClient(c.mongo_uri)
 database = client.linkage_agent
 
 
-results = database.match_groups.aggregate([
-    {
-        '$unwind': "$run_results"
-    },
-    {
-        '$group': {
-            '_id': '$run_results.project',
-            'total': {'$sum': 1}
-        }
-    }
-])
+results = database.match_groups.aggregate(
+    [
+        {"$unwind": "$run_results"},
+        {"$group": {"_id": "$run_results.project", "total": {"$sum": 1}}},
+    ]
+)
 
 for result in results:
     print(result)

--- a/dcctools/project_review.py
+++ b/dcctools/project_review.py
@@ -50,10 +50,10 @@ with open(link_id_csv_path) as csvfile:
 def result_matching_fn(result):
     def matching_fn(r):
         all(
-            k == "run_results" or
-                 (k in r and int(r[k]) in result[k])
-                 for k in result.keys()
+            k == "run_results" or (k in r and int(r[k]) in result[k])
+            for k in result.keys()
         )
+
     return matching_fn
 
 

--- a/dcctools/project_review.py
+++ b/dcctools/project_review.py
@@ -1,12 +1,11 @@
-from pathlib import Path
-import time
 import argparse
 import csv
+import time
+from pathlib import Path
 from pprint import pprint as pp
 
-from pymongo import MongoClient
-
 from config import Configuration
+from pymongo import MongoClient
 
 c = Configuration("config.json")
 client = MongoClient(c.mongo_uri)

--- a/dcctools/project_review.py
+++ b/dcctools/project_review.py
@@ -15,7 +15,7 @@ database = client.linkage_agent
 link_id_csv_path = Path(c.matching_results_folder) / "link_ids.csv"
 
 
-CSV_HEADERS = ['link_id', 'removed_project']
+CSV_HEADERS = ["link_id", "removed_project"]
 
 for s in c.systems:
     CSV_HEADERS.append(s)
@@ -41,8 +41,7 @@ for system in c.systems:
 with open(link_id_csv_path) as csvfile:
     link_id_rows = csv.DictReader(csvfile)
     # drop keys with empty string values
-    link_id_rows = list(map(lambda r: {k: v for k, v in r.items() if v},
-                            link_id_rows))
+    link_id_rows = list(map(lambda r: {k: v for k, v in r.items() if v}, link_id_rows))
     for row in link_id_rows:
         for system in c.systems:
             if system in row and row[system]:
@@ -64,57 +63,67 @@ def find_link_id_row(result):
     # If we make it here, all systems in this matching result
     # have more than one position listed,
     # so fall back to the old, slow, loop approach
-    matching_fn = lambda r: all(k == 'run_results' or (k in r and int(r[k]) in result[k]) for k in result.keys())
+    matching_fn = lambda r: all(
+        k == "run_results" or (k in r and int(r[k]) in result[k]) for k in result.keys()
+    )
     link_id_row = next(filter(matching_fn, link_id_rows))
     return link_id_row
 
 
 def describe(changed, project, args):
-    link_id_row = changed['link_id_row']
-    link_id = link_id_row['LINK_ID']
+    link_id_row = changed["link_id_row"]
+    link_id = link_id_row["LINK_ID"]
     if args.linkids:
         print(link_id)
     else:
-        if 'new' not in changed or len(changed['new']) == 0:
-            sites = changed['original'].keys() - set(['run_results'])
+        if "new" not in changed or len(changed["new"]) == 0:
+            sites = changed["original"].keys() - set(["run_results"])
 
             if args.csv:
                 csv_cells = [link_id, project]
 
                 for s in c.systems:
-                    action = 'dropped' if s in sites else ''
-                    s_id = link_id_row[s] if s in link_id_row else ''
+                    action = "dropped" if s in sites else ""
+                    s_id = link_id_row[s] if s in link_id_row else ""
                     csv_cells.append(action)
                     csv_cells.append(s_id)
 
-                print(','.join(csv_cells))
+                print(",".join(csv_cells))
 
             else:
-                print(f"LINKID {link_id} was created using only {project}\
- -- sites: {list(sites)}")
+                print(
+                    f"LINKID {link_id} was created using only {project}\
+ -- sites: {list(sites)}"
+                )
         else:
-            delta = changed['original'].keys() - changed['new'].keys() - set(['run_results'])
+            delta = (
+                changed["original"].keys()
+                - changed["new"].keys()
+                - set(["run_results"])
+            )
 
             if args.csv:
                 csv_cells = [link_id, project]
 
                 for s in c.systems:
                     if s in delta:
-                        action = 'dropped'
-                    elif s in changed['original']:
-                        action = 'retained'
+                        action = "dropped"
+                    elif s in changed["original"]:
+                        action = "retained"
                     else:
-                        action = ''
+                        action = ""
 
-                    s_id = link_id_row[s] if s in link_id_row else ''
+                    s_id = link_id_row[s] if s in link_id_row else ""
 
                     csv_cells.append(action)
                     csv_cells.append(s_id)
 
-                print(','.join(csv_cells))
+                print(",".join(csv_cells))
             else:
-                print(f"LINKID {link_id} links to {' and '.join(delta)} only by {project}\
- -- remaining links are {list(changed['new'].keys())}")
+                print(
+                    f"LINKID {link_id} links to {' and '.join(delta)} only by {project}\
+ -- remaining links are {list(changed['new'].keys())}"
+                )
 
     if args.debug:
         pp(changed)
@@ -127,23 +136,30 @@ def main():
     )
 
     parser.add_argument(
-        "-p", "--project",
+        "-p",
+        "--project",
         help="Select a project to test removing. \
               Default: iterate through all defined projects",
     )
 
     parser.add_argument(
-        "-l", "--linkids", action="store_true",
+        "-l",
+        "--linkids",
+        action="store_true",
         help="Print out ONLY the LINKIDs without additional description",
     )
 
     parser.add_argument(
-        "-c", "--csv", action="store_true",
+        "-c",
+        "--csv",
+        action="store_true",
         help="Print output in a CSV format",
     )
 
     parser.add_argument(
-        "-d", "--debug", action="store_true",
+        "-d",
+        "--debug",
+        action="store_true",
         help="Print out additional detail for debugging",
     )
 
@@ -151,22 +167,17 @@ def main():
 
     # get some overall analytics. total match pairs, total links
     if args.csv:
-        print(','.join(CSV_HEADERS))
+        print(",".join(CSV_HEADERS))
 
     else:
         total = database.match_groups.count_documents({})
         print(f"Total number of matches: {total}")
 
-        total = database.match_groups.aggregate([{
-            "$group": {
-                "_id": None,
-                "count": {
-                    "$sum": {"$size": "$run_results"}
-                }
-            }
-        }])
+        total = database.match_groups.aggregate(
+            [{"$group": {"_id": None, "count": {"$sum": {"$size": "$run_results"}}}}]
+        )
         for doc in total:  # should only be one result in the cursor
-            count = doc['count']
+            count = doc["count"]
             print(f"Total number of matched pairs (run_results): {count}")
 
     for project in c.projects:
@@ -188,13 +199,14 @@ def main():
         if count:
             results = database.match_groups.find(only_this_project, {"_id": 0})
             for result in results:
-                changed_results.append({'original': result,
-                                        'link_id_row': find_link_id_row(result)})
+                changed_results.append(
+                    {"original": result, "link_id_row": find_link_id_row(result)}
+                )
 
         # find results that would be different if this project were excluded
         results = database.match_groups.find(query, {"_id": 0})
         for result in results:
-            if len(result['run_results']) == 1:
+            if len(result["run_results"]) == 1:
                 continue  # already addressed in the "match ONLY on" logic ^
 
             # sample result:
@@ -233,12 +245,12 @@ def main():
 
             new_result = {}
 
-            for project_result in result['run_results']:
-                if project_result['project'] == project:
+            for project_result in result["run_results"]:
+                if project_result["project"] == project:
                     continue
 
                 for key, value in project_result.items():
-                    if key == 'project':
+                    if key == "project":
                         continue
 
                     if key not in new_result:
@@ -248,15 +260,19 @@ def main():
 
             # now compare the old result to the new result, see what changed
             for key, value in result.items():
-                if key in ['run_results', '_id']:
+                if key in ["run_results", "_id"]:
                     continue
 
                 if key not in new_result or set(value) != new_result[key]:
                     # find the link_id belonging to this result
                     link_id_row = find_link_id_row(result)
-                    changed_results.append({'original': result,
-                                            'new': new_result,
-                                            'link_id_row': link_id_row})
+                    changed_results.append(
+                        {
+                            "original": result,
+                            "new": new_result,
+                            "link_id_row": link_id_row,
+                        }
+                    )
                     break
 
         count = len(changed_results)
@@ -271,5 +287,5 @@ def main():
             print()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/dcctools/project_review.py
+++ b/dcctools/project_review.py
@@ -1,6 +1,5 @@
 import argparse
 import csv
-import time
 from pathlib import Path
 from pprint import pprint as pp
 
@@ -48,6 +47,16 @@ with open(link_id_csv_path) as csvfile:
                 link_id_dict[system][pos] = row
 
 
+def result_matching_fn(result):
+    def matching_fn(r):
+        all(
+            k == "run_results" or
+                 (k in r and int(r[k]) in result[k])
+                 for k in result.keys()
+        )
+    return matching_fn
+
+
 def find_link_id_row(result):
     for system in c.systems:
         if system in result and result[system] and len(result[system]) == 1:
@@ -62,9 +71,7 @@ def find_link_id_row(result):
     # If we make it here, all systems in this matching result
     # have more than one position listed,
     # so fall back to the old, slow, loop approach
-    matching_fn = lambda r: all(
-        k == "run_results" or (k in r and int(r[k]) in result[k]) for k in result.keys()
-    )
+    matching_fn = result_matching_fn(result)
     link_id_row = next(filter(matching_fn, link_id_rows))
     return link_id_row
 

--- a/definitions.py
+++ b/definitions.py
@@ -1,4 +1,3 @@
 import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-

--- a/link_ids.py
+++ b/link_ids.py
@@ -66,7 +66,7 @@ def do_link_ids(c, remove=False):
                 final_record = {}
                 for s in systems:
                     record_id = row.get(s, None)
-                    if record_id != None:
+                    if record_id is not None:
                         final_record[s] = record_id[0]
                         all_ids_for_households[s].remove(record_id[0])
                 final_records.append(final_record)
@@ -95,7 +95,7 @@ def do_link_ids(c, remove=False):
                 else:
                     for s in systems:
                         record_id = row.get(s, None)
-                        if record_id != None:
+                        if record_id is not None:
                             final_record[s] = record_id[0]
                             all_ids_for_systems[s].remove(record_id[0])
                 final_record["LINK_ID"] = uuid.uuid1()
@@ -117,7 +117,8 @@ def do_link_ids(c, remove=False):
         print("Match groups deleted from database")
     else:
         print(
-            "Match groups not deleted as this point (they might be deleted later in the process)"
+            "Match groups not deleted as this point"
+            "(they might be deleted later in the process)"
         )
 
 

--- a/link_ids.py
+++ b/link_ids.py
@@ -2,10 +2,10 @@
 
 import argparse
 import csv
-from functools import reduce
 import json
-from pathlib import Path
 import uuid
+from functools import reduce
+from pathlib import Path
 
 from pymongo import MongoClient
 

--- a/match.py
+++ b/match.py
@@ -18,7 +18,9 @@ log = logging.getLogger(__name__)
 
 class MissingResults(Exception):
     def __init__(self, expected_results, available_results, message=None):
-        message = message if message else self.message(expected_results, available_results)
+        message = (
+            message if message else self.message(expected_results, available_results)
+        )
         super().__init__(message)
 
     def message(self, expected_results, available_results):
@@ -40,9 +42,11 @@ def parse_args():
 
 
 def has_results_available(config, projects=None):
-    available_results = set(map(lambda x: x.stem, Path(config.project_results_dir).glob('*.json')))
+    available_results = set(
+        map(lambda x: x.stem, Path(config.project_results_dir).glob("*.json"))
+    )
     expected_results = set(projects) if projects else set(config.projects)
-    if (expected_results <= available_results):
+    if expected_results <= available_results:
         return True
     else:
         raise MissingResults(expected_results, available_results)
@@ -60,10 +64,10 @@ def do_match(config, projects=None):
 def do_matching(config, projects, collection):
     has_results_available(config, projects)
     for project_name in projects:
-        with open(Path(config.project_results_dir) / f'{project_name}.json') as file:
+        with open(Path(config.project_results_dir) / f"{project_name}.json") as file:
             result_json = json.load(file)
             results = Results(config.systems, project_name, result_json)
-            print(f'Matching for project: {project_name}')
+            print(f"Matching for project: {project_name}")
             results.insert_results(collection)
 
 

--- a/match.py
+++ b/match.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import argparse
+import json
 import logging
 from pathlib import Path
-import json
 
 from pymongo import MongoClient
 

--- a/projects.py
+++ b/projects.py
@@ -14,6 +14,7 @@ SLEEP_TIME = 10.0
 
 log = logging.getLogger(__name__)
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -24,10 +25,9 @@ def parse_args():
     parser.add_argument(
         "--verbose", default=False, action="store_true", help="Show debugging output"
     )
-    parser.add_argument(
-        "--project", default=None, help="Run specific project only"
-    )
+    parser.add_argument("--project", default=None, help="Run specific project only")
     return parser.parse_args()
+
 
 def run_projects(c, project_name=None):
     if c.household_match:
@@ -47,27 +47,24 @@ def run_projects(c, project_name=None):
             for project_name in c.load_schema().keys():
                 run_project(c, project_name)
 
+
 def run_project(c, project_name=None, households=False):
     schema = c.load_household_schema() if households else c.load_schema()[project_name]
-    project = Project(
-        project_name, schema, c.systems, c.entity_service_url, c.blocked
-    )
+    project = Project(project_name, schema, c.systems, c.entity_service_url, c.blocked)
     project.start_project()
 
     for system in c.systems:
-            if households:
-                project.upload_clks(
-                    system, c.get_household_clks_raw(system, project_name)
+        if households:
+            project.upload_clks(system, c.get_household_clks_raw(system, project_name))
+        else:
+            if c.blocked:
+                project.upload_clks_blocked(
+                    system,
+                    c.get_clk(system, project_name),
+                    c.get_block(system, project_name),
                 )
             else:
-                if c.blocked:
-                    project.upload_clks_blocked(
-                        system,
-                        c.get_clk(system, project_name),
-                        c.get_block(system, project_name),
-                    )
-                else:
-                    project.upload_clks(system, c.get_clks_raw(system, project_name))
+                project.upload_clks(system, c.get_clks_raw(system, project_name))
     threshold = c.get_project_threshold(project_name)
     project.start_run(threshold)
     running = True
@@ -82,8 +79,9 @@ def run_project(c, project_name=None, households=False):
     print("\n--- Getting results ---\n")
     result_json = project.get_results()
     Path(c.project_results_dir).mkdir(parents=True, exist_ok=True)
-    with open(Path(c.project_results_dir) / f'{project_name}.json', 'w') as json_file:
+    with open(Path(c.project_results_dir) / f"{project_name}.json", "w") as json_file:
         json.dump(result_json, json_file)
+
 
 if __name__ == "__main__":
     args = parse_args()
@@ -91,4 +89,3 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.DEBUG, format="%(message)s")
     config = Configuration(args.config)
     run_projects(config, args.project)
-

--- a/projects.py
+++ b/projects.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
-import logging
-from pathlib import Path
-import time
 import json
+import logging
+import time
+from pathlib import Path
 
 from dcctools.anonlink import Project
 from dcctools.config import Configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==22.3.0
+flake8==4.0.1
 pytest>=7.1.2
 requests>=2.20.0
 pymongo>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 black==22.3.0
 flake8==4.0.1
+isort==5.10.1
 pytest>=7.1.2
 requests>=2.20.0
 pymongo>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+black==22.3.0
 pytest>=7.1.2
 requests>=2.20.0
 pymongo>=3.11.2

--- a/test/linkage-agent/individual-steps/a_test_drop.py
+++ b/test/linkage-agent/individual-steps/a_test_drop.py
@@ -7,4 +7,3 @@ def test_drop():
     config = cu.get_config("test-data/defaults/config.json")
     lau.drop(config)
     print("Done.")
-

--- a/test/linkage-agent/individual-steps/b_test_validate.py
+++ b/test/linkage-agent/individual-steps/b_test_validate.py
@@ -7,4 +7,3 @@ def test_validate():
     config = cu.get_config("test-data/defaults/config.json")
     lau.validate(config)
     print("Done.")
-

--- a/test/linkage-agent/individual-steps/c_test_match.py
+++ b/test/linkage-agent/individual-steps/c_test_match.py
@@ -9,4 +9,3 @@ def test_match():
     lau.projects(config)
     lau.match(config)
     print("Done.")
-

--- a/test/linkage-agent/individual-steps/d_test_link_ids.py
+++ b/test/linkage-agent/individual-steps/d_test_link_ids.py
@@ -19,4 +19,3 @@ def test_match():
     lau.data_owner_ids(config)
     # No drop done at the end so we can look at the data after the run if we need to
     print("Done.")
-

--- a/test/linkage-agent/manual/hello_world.py
+++ b/test/linkage-agent/manual/hello_world.py
@@ -1,4 +1,3 @@
-import test_util.linkage.run_full_linkage_test as flt
 
 
 def run_test():

--- a/test/linkage-agent/manual/hello_world.py
+++ b/test/linkage-agent/manual/hello_world.py
@@ -1,5 +1,3 @@
-
-
 def run_test():
     print("Starting test...")
     print("Hello world")

--- a/test/linkage-agent/manual/hello_world.py
+++ b/test/linkage-agent/manual/hello_world.py
@@ -9,7 +9,3 @@ def run_test():
 
 if __name__ == "__main__":
     run_test()
-
-
-
-

--- a/test/linkage-agent/manual/run_small_test_with_matches-single-schema.py
+++ b/test/linkage-agent/manual/run_small_test_with_matches-single-schema.py
@@ -3,13 +3,11 @@ import test_util.linkage.run_full_linkage_test as flt
 
 def run_test():
     print("Starting test...")
-    flt.run_full_linkage_test("test-data/envs/small-no-households-with-matches-single-schema/config.json")
+    flt.run_full_linkage_test(
+        "test-data/envs/small-no-households-with-matches-single-schema/config.json"
+    )
     print("Done with test")
 
 
 if __name__ == "__main__":
     run_test()
-
-
-
-

--- a/test/linkage-agent/manual/run_small_test_with_matches.py
+++ b/test/linkage-agent/manual/run_small_test_with_matches.py
@@ -3,13 +3,11 @@ import test_util.linkage.run_full_linkage_test as flt
 
 def run_test():
     print("Starting test...")
-    flt.run_full_linkage_test("test-data/envs/small-no-households-with-matches/config.json")
+    flt.run_full_linkage_test(
+        "test-data/envs/small-no-households-with-matches/config.json"
+    )
     print("Done with test")
 
 
 if __name__ == "__main__":
     run_test()
-
-
-
-

--- a/test/linkage-agent/no-drop/generate-link-ids-skipping-drop.py
+++ b/test/linkage-agent/no-drop/generate-link-ids-skipping-drop.py
@@ -1,7 +1,6 @@
 import util.config.config_util as cu
 import util.linkage_agent.linkage_agent_util as lau
 
-
 # ---
 #
 # This test case can be used to trouble shoot MongoDB issues.

--- a/test/linkage-agent/no-drop/generate-link-ids-skipping-drop.py
+++ b/test/linkage-agent/no-drop/generate-link-ids-skipping-drop.py
@@ -29,4 +29,3 @@ def run_test_match():
 
 if __name__ == "__main__":
     run_test_match()
-

--- a/test/linkage-agent/no-household/test_link_ids_with_no_households.py
+++ b/test/linkage-agent/no-household/test_link_ids_with_no_households.py
@@ -20,4 +20,3 @@ def test_match():
     print("Doing drop...")
     lau.drop(config)
     print("Done.")
-

--- a/test/linkage-agent/time-test/test_time_test_runner.py
+++ b/test/linkage-agent/time-test/test_time_test_runner.py
@@ -9,4 +9,3 @@ def test_time_test_runner():
     root_dir_name = fu.get_file_name(root_dir)
     patient_dirs = fu.get_dirs(fu.get_file_name(root_dir + "/patients"))
     ttr.run_time_test(root_dir_name, patient_dirs, config)
-

--- a/test/util/config/test_config_util.py
+++ b/test/util/config/test_config_util.py
@@ -14,4 +14,3 @@ def test_get_config():
     config = cu.get_config("test/util/config/config.json")
     print(ju.pretty_print(config.config_json))
     print("Done.")
-

--- a/tests/anonlink_test.py
+++ b/tests/anonlink_test.py
@@ -1,6 +1,3 @@
-import os
-
-import pytest
 from pymongo import MongoClient
 
 from dcctools.anonlink import Results

--- a/tests/anonlink_test.py
+++ b/tests/anonlink_test.py
@@ -1,7 +1,7 @@
 import os
 
-from pymongo import MongoClient
 import pytest
+from pymongo import MongoClient
 
 from dcctools.anonlink import Results
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,4 +1,3 @@
-
 import util.config.config_util as cu
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -11,7 +11,7 @@ def test_system_count():
     found = c.system_count
     print("Expected: " + str(expected))
     print("Found:    " + str(found))
-    assert (expected == found)
+    assert expected == found
 
 
 def test_validate_all_present():
@@ -40,7 +40,7 @@ def test_validate_config():
         f"Number of projects ({n_expected_proj}) and thresholds ({n_expected_thresh}) is unequal \
                 \n\tThreshold must either be float or list of floats equal in length to the number of projects"
     ]
-    
+
     c_multi_thresh = cu.get_config("tests/mock_setup/config-multi-threshold.json")
     actual_issues = c_multi_thresh.validate_config()
     assert len(expected_issues) == len(actual_issues)
@@ -48,9 +48,10 @@ def test_validate_config():
         assert actual_issues[i] == expected_issue
 
     c_hh_no_thresh = cu.get_config("tests/mock_setup/config-hh-no-thresh.json")
-    expected_issues = ["config file specifies household match without float household matching threshold"]
+    expected_issues = [
+        "config file specifies household match without float household matching threshold"
+    ]
     actual_issues = c_hh_no_thresh.validate_config()
     assert len(expected_issues) == len(actual_issues)
     for i, expected_issue in enumerate(expected_issues):
         assert actual_issues[i] == expected_issue
-

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,7 +1,6 @@
 import pytest
+
 import util.config.config_util as cu
-
-
 from dcctools.config import Configuration
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,7 +1,5 @@
-import pytest
 
 import util.config.config_util as cu
-from dcctools.config import Configuration
 
 
 def test_system_count():
@@ -36,8 +34,10 @@ def test_validate_config():
     n_expected_proj = 4
     n_expected_thresh = 3
     expected_issues = [
-        f"Number of projects ({n_expected_proj}) and thresholds ({n_expected_thresh}) is unequal \
-                \n\tThreshold must either be float or list of floats equal in length to the number of projects"
+        f"Number of projects ({n_expected_proj}) and thresholds \
+                ({n_expected_thresh}) is unequal \
+                \n\tThreshold must either be float \
+                or list of floats equal in length to the number of projects"
     ]
 
     c_multi_thresh = cu.get_config("tests/mock_setup/config-multi-threshold.json")
@@ -48,7 +48,8 @@ def test_validate_config():
 
     c_hh_no_thresh = cu.get_config("tests/mock_setup/config-hh-no-thresh.json")
     expected_issues = [
-        "config file specifies household match without float household matching threshold"
+        "config file specifies household match \
+                without float household matching threshold"
     ]
     actual_issues = c_hh_no_thresh.validate_config()
     assert len(expected_issues) == len(actual_issues)

--- a/tests/deconflict_test.py
+++ b/tests/deconflict_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dcctools.deconflict import link_count, deconflict
+from dcctools.deconflict import deconflict, link_count
 
 example_result = {
     "a": [142],

--- a/tests/deconflict_test.py
+++ b/tests/deconflict_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from dcctools.deconflict import deconflict, link_count
 
 example_result = {

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -22,45 +22,59 @@ class MockResults:
 
 class MockMongo:
     def __init__(self, mongo_uri):
-        self.linkage_agent = type('', (), dict(match_groups=None, household_match_groups=None))
+        self.linkage_agent = type(
+            "", (), dict(match_groups=None, household_match_groups=None)
+        )
 
-@pytest.mark.parametrize('available,expected,result', [
-    pytest.param(['foo', 'bar', 'quz'], ['foo', 'bar', 'quz'], True),  # Exact match
-    pytest.param(['foo', 'bar', 'quz', 'cat'], ['foo', 'bar', 'quz'], True),  # Subset
-    pytest.param(['foo', 'bar', 'cat'], ['foo', 'bar', 'baz'], False),  # Missing `baz`
-])
+
+@pytest.mark.parametrize(
+    "available,expected,result",
+    [
+        pytest.param(["foo", "bar", "quz"], ["foo", "bar", "quz"], True),  # Exact match
+        pytest.param(
+            ["foo", "bar", "quz", "cat"], ["foo", "bar", "quz"], True
+        ),  # Subset
+        pytest.param(
+            ["foo", "bar", "cat"], ["foo", "bar", "baz"], False
+        ),  # Missing `baz`
+    ],
+)
 def test_has_results_available(tmp_path, available, expected, result):
-    d = tmp_path / 'codi_test_results'
+    d = tmp_path / "codi_test_results"
     d.mkdir()
     for file in available:
-        (d / f'{file}.json').touch()
+        (d / f"{file}.json").touch()
 
     if result:
         assert has_results_available(MockConfiguration(str(d), expected))
         # Configuration should be ignored when projects are specifically passed in
-        assert has_results_available(MockConfiguration(str(d), ['fake']), expected)
+        assert has_results_available(MockConfiguration(str(d), ["fake"]), expected)
     else:
         with pytest.raises(MissingResults, match="Missing results for projects: baz"):
             has_results_available(MockConfiguration(str(d), expected))
         with pytest.raises(MissingResults, match="Missing results for projects: baz"):
-            has_results_available(MockConfiguration(str(d), ['fake']), expected)
+            has_results_available(MockConfiguration(str(d), ["fake"]), expected)
 
-@pytest.mark.parametrize('available,expected,household,result', [
-    pytest.param(['foo', 'bar', 'quz'], ['foo', 'bar', 'quz'], False, True),
-    pytest.param(['foo', 'bar', 'quz', 'cat'], ['foo', 'bar', 'quz'], False, True),
-    pytest.param(['foo', 'bar', 'cat'], ['foo', 'bar', 'quz'], False, False),
-    # HouseHold Tests
-    pytest.param(['fn-phone-addr-zip'], ['fn-phone-addr-zip'], True, True),
-    pytest.param(['fn-phone-addr-zip'], ['foo'], True, True),
-    pytest.param(['fn-phone-addr-zip', 'bar'], ['foo'], True, True),
-    pytest.param(['foo'], ['fn-phone-addr-zip'], True, False),
-])
+
+@pytest.mark.parametrize(
+    "available,expected,household,result",
+    [
+        pytest.param(["foo", "bar", "quz"], ["foo", "bar", "quz"], False, True),
+        pytest.param(["foo", "bar", "quz", "cat"], ["foo", "bar", "quz"], False, True),
+        pytest.param(["foo", "bar", "cat"], ["foo", "bar", "quz"], False, False),
+        # HouseHold Tests
+        pytest.param(["fn-phone-addr-zip"], ["fn-phone-addr-zip"], True, True),
+        pytest.param(["fn-phone-addr-zip"], ["foo"], True, True),
+        pytest.param(["fn-phone-addr-zip", "bar"], ["foo"], True, True),
+        pytest.param(["foo"], ["fn-phone-addr-zip"], True, False),
+    ],
+)
 def test_do_match(monkeypatch, tmp_path, available, expected, household, result):
-    d = tmp_path / 'codi_test_results'
+    d = tmp_path / "codi_test_results"
     d.mkdir()
     content = "{}"
     for file in available:
-        (d / f'{file}.json').write_text(content)
+        (d / f"{file}.json").write_text(content)
 
     monkeypatch.setattr("match.Results", MockResults)
     monkeypatch.setattr("match.MongoClient", MockMongo)
@@ -68,7 +82,7 @@ def test_do_match(monkeypatch, tmp_path, available, expected, household, result)
     try:
         do_match(MockConfiguration(str(d), expected, household))
         # Configuration should be ignored when projects are specifically passed in
-        do_match(MockConfiguration(str(d), ['fake'], household), expected)
+        do_match(MockConfiguration(str(d), ["fake"], household), expected)
         assert result
     except MissingResults:
         assert not result

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,5 +1,6 @@
 import pytest
-from match import MissingResults, has_results_available, do_match
+
+from match import MissingResults, do_match, has_results_available
 
 
 class MockConfiguration:

--- a/time_test.py
+++ b/time_test.py
@@ -24,7 +24,8 @@ if __name__ == "__main__":
     # get the args from the cmd line
     print("Reading arguments...")
     parser = argparse.ArgumentParser(
-        description="Tool for running time tests for generating LINK_IDs in the CODI PPRL process"
+        description="Tool for running time tests for"
+        "generating LINK_IDs in the CODI PPRL process"
     )
     parser.add_argument(
         "--dir",

--- a/time_test.py
+++ b/time_test.py
@@ -35,4 +35,3 @@ if __name__ == "__main__":
     # get the derived params
     root_dir = args.dir
     run_test(root_dir)
-

--- a/time_test.py
+++ b/time_test.py
@@ -2,8 +2,8 @@ import argparse
 from pathlib import Path
 
 import util.config.config_util as cu
-import util.linkage_agent.time_test_runner as ttr
 import util.file.file_util as fu
+import util.linkage_agent.time_test_runner as ttr
 
 
 def run_test(root_dir_abs_path):

--- a/tuning-files-scripts/household_score.py
+++ b/tuning-files-scripts/household_score.py
@@ -1,8 +1,9 @@
-import csv
-from pathlib import Path
-from dcctools.config import Configuration
-from itertools import combinations
 import argparse
+import csv
+from itertools import combinations
+from pathlib import Path
+
+from dcctools.config import Configuration
 
 parser = argparse.ArgumentParser(
     description="Tool for scoring household linkage results"

--- a/tuning-files-scripts/household_score.py
+++ b/tuning-files-scripts/household_score.py
@@ -4,8 +4,12 @@ from dcctools.config import Configuration
 from itertools import combinations
 import argparse
 
-parser = argparse.ArgumentParser(description='Tool for scoring household linkage results')
-parser.add_argument('--dotools', nargs=1, required=True, help='data-owner-tools project path')
+parser = argparse.ArgumentParser(
+    description="Tool for scoring household linkage results"
+)
+parser.add_argument(
+    "--dotools", nargs=1, required=True, help="data-owner-tools project path"
+)
 args = parser.parse_args()
 
 data_owner_tools_path = Path(args.dotools[0])
@@ -23,63 +27,75 @@ household_pair_count = 0
 household_answer_count = 0
 
 hid_csv_path = Path(c.matching_results_folder) / "household_id_link_ids.csv"
-answer_key_path = Path(data_owner_tools_path) / 'temp-data/full_answer_key.csv'
+answer_key_path = Path(data_owner_tools_path) / "temp-data/full_answer_key.csv"
 
 answer_key_rows = []
 with open(answer_key_path) as key_csv:
-  key_reader = csv.reader(key_csv)
-  next(key_reader)
-  for row in key_reader:
-    household_answer_count += 1
-    answer_key_rows.append(row)
-    hids = list(filter(lambda id: len(id) > 0, row))
-    combos = combinations(hids, 2)
-    for a, b in combos:
-      household_pair_count += 1
+    key_reader = csv.reader(key_csv)
+    next(key_reader)
+    for row in key_reader:
+        household_answer_count += 1
+        answer_key_rows.append(row)
+        hids = list(filter(lambda id: len(id) > 0, row))
+        combos = combinations(hids, 2)
+        for a, b in combos:
+            household_pair_count += 1
 # Decide if we want to use all_hids with the list(set()) deduping or the partial count+=
-all_hids = [] # remove
+all_hids = []  # remove
 with open(hid_csv_path) as hid_csv:
-  hid_reader = csv.reader(hid_csv)
-  next(hid_reader)
-  for row in hid_reader:
-    hids = row[1:(len(systems)+1)]
-    hids_filtered = list(filter(lambda id: len(id) > 0, hids))
-    if hids in answer_key_rows:
-      perfect_true_positives += 1
-    elif len(hids_filtered) > 1:
-      # Review if this makes sense or we need additional filter
-      perfect_false_positives += 1
+    hid_reader = csv.reader(hid_csv)
+    next(hid_reader)
+    for row in hid_reader:
+        hids = row[1 : (len(systems) + 1)]
+        hids_filtered = list(filter(lambda id: len(id) > 0, hids))
+        if hids in answer_key_rows:
+            perfect_true_positives += 1
+        elif len(hids_filtered) > 1:
+            # Review if this makes sense or we need additional filter
+            perfect_false_positives += 1
 
-    combos = combinations(hids_filtered, 2)
-    if len(hids_filtered) > 1 and all(a == b for (a,b) in combos):
-      all_hids.append(hids_filtered[0])
-      # partial_true_positives += 1
-    elif len(hids_filtered) == 1 and hids in answer_key_rows:
-      all_hids.append(hids_filtered[0])
-      # partial_true_positives += 1
-    elif len(hids_filtered) > 1:
-      partial_false_positives += 1
+        combos = combinations(hids_filtered, 2)
+        if len(hids_filtered) > 1 and all(a == b for (a, b) in combos):
+            all_hids.append(hids_filtered[0])
+            # partial_true_positives += 1
+        elif len(hids_filtered) == 1 and hids in answer_key_rows:
+            all_hids.append(hids_filtered[0])
+            # partial_true_positives += 1
+        elif len(hids_filtered) > 1:
+            partial_false_positives += 1
 
-    combos = combinations(hids_filtered, 2)
-    for a, b in combos:
-      if a == b:
-        true_positives += 1
-      else:
-        false_positives += 1
+        combos = combinations(hids_filtered, 2)
+        for a, b in combos:
+            if a == b:
+                true_positives += 1
+            else:
+                false_positives += 1
 
 partial_true_positives = len(list(set(all_hids)))
 
 precision = true_positives / (true_positives + false_positives)
 recall = true_positives / household_pair_count
 fscore = 2 * ((precision * recall) / (precision + recall))
-print("Pair-wise scoring:\nPrecision: {} Recall: {} F-Score: {}".format(precision, recall, fscore))
+print(
+    "Pair-wise scoring:\nPrecision: {} Recall: {} F-Score: {}".format(
+        precision, recall, fscore
+    )
+)
 
 precision = perfect_true_positives / (perfect_true_positives + perfect_false_positives)
 recall = perfect_true_positives / household_answer_count
 fscore = 2 * ((precision * recall) / (precision + recall))
-print("Perfect scoring:\nPrecision: {} Recall: {} F-Score: {}".format(precision, recall, fscore))
+print(
+    "Perfect scoring:\nPrecision: {} Recall: {} F-Score: {}".format(
+        precision, recall, fscore
+    )
+)
 
 precision = partial_true_positives / (partial_true_positives + partial_false_positives)
 recall = partial_true_positives / household_answer_count
 fscore = 2 * ((precision * recall) / (precision + recall))
-print("Partial scoring:\nPrecision: {} Recall: {} F-Score: {}".format(precision, recall, fscore))
+print(
+    "Partial scoring:\nPrecision: {} Recall: {} F-Score: {}".format(
+        precision, recall, fscore
+    )
+)

--- a/tuning-files-scripts/patid_translate.py
+++ b/tuning-files-scripts/patid_translate.py
@@ -5,41 +5,45 @@ import sys
 
 from dcctools.config import Configuration
 
-parser = argparse.ArgumentParser(description='Tool for translating linkage table to patid table for scoring')
-parser.add_argument('--dotools', nargs=1, required=True, help='data-owner-tools project path')
+parser = argparse.ArgumentParser(
+    description="Tool for translating linkage table to patid table for scoring"
+)
+parser.add_argument(
+    "--dotools", nargs=1, required=True, help="data-owner-tools project path"
+)
 args = parser.parse_args()
 
 data_owner_tools_path = Path(args.dotools[0])
 
 c = Configuration("config.json")
 systems = c.systems
-header = ['LINK_ID']
+header = ["LINK_ID"]
 header.extend(systems)
 
 pii_line_map = {}
 
 for s in systems:
-  pii_csv_path = Path(data_owner_tools_path) / "temp-data/pii_{}.csv".format(s)
-  with open(pii_csv_path) as pii_csv:
-    pii_reader = csv.reader(pii_csv)
-    next(pii_reader)
-    pii_line_map[s] = list(pii_reader)
+    pii_csv_path = Path(data_owner_tools_path) / "temp-data/pii_{}.csv".format(s)
+    with open(pii_csv_path) as pii_csv:
+        pii_reader = csv.reader(pii_csv)
+        next(pii_reader)
+        pii_line_map[s] = list(pii_reader)
 
 result_csv_path = Path(c.matching_results_folder) / "link_ids.csv"
 patid_csv_path = Path(c.matching_results_folder) / "patid_link_ids.csv"
 
 with open(result_csv_path) as csvfile:
-  link_id_reader = csv.DictReader(csvfile)
-  with open(patid_csv_path, 'w', newline='', encoding='utf-8') as patid_file:
-    writer = csv.DictWriter(patid_file, fieldnames=header)
-    writer.writeheader()
-    for link in link_id_reader:
-      row = {'LINK_ID': link['LINK_ID']}
-      for s in systems:
-        if len(link[s]) > 0:
-          pii_line = link[s]
-          patid = pii_line_map[s][int(pii_line)][0]
-          row[s] = patid
-      writer.writerow(row)
+    link_id_reader = csv.DictReader(csvfile)
+    with open(patid_csv_path, "w", newline="", encoding="utf-8") as patid_file:
+        writer = csv.DictWriter(patid_file, fieldnames=header)
+        writer.writeheader()
+        for link in link_id_reader:
+            row = {"LINK_ID": link["LINK_ID"]}
+            for s in systems:
+                if len(link[s]) > 0:
+                    pii_line = link[s]
+                    patid = pii_line_map[s][int(pii_line)][0]
+                    row[s] = patid
+            writer.writerow(row)
 
-print('results/patid_link_ids.csv created')
+print("results/patid_link_ids.csv created")

--- a/tuning-files-scripts/patid_translate.py
+++ b/tuning-files-scripts/patid_translate.py
@@ -1,7 +1,7 @@
-import csv
-from pathlib import Path
 import argparse
+import csv
 import sys
+from pathlib import Path
 
 from dcctools.config import Configuration
 

--- a/tuning-files-scripts/patid_translate.py
+++ b/tuning-files-scripts/patid_translate.py
@@ -1,6 +1,5 @@
 import argparse
 import csv
-import sys
 from pathlib import Path
 
 from dcctools.config import Configuration

--- a/tuning-files-scripts/score.py
+++ b/tuning-files-scripts/score.py
@@ -4,53 +4,47 @@ from dcctools.config import Configuration
 from itertools import combinations
 import argparse
 
-parser = argparse.ArgumentParser(description='Tool for scoring individual linkage results')
-parser.add_argument('--answerkey', nargs=1, required=True, help='Path to answer key file')
+parser = argparse.ArgumentParser(
+    description="Tool for scoring individual linkage results"
+)
+parser.add_argument(
+    "--answerkey", nargs=1, required=True, help="Path to answer key file"
+)
 args = parser.parse_args()
 
 answer_key_file = Path(args.answerkey[0])
-​
 c = Configuration("config.json")
 systems = c.systems
-​
 true_positives = 0
 false_positives = 0
-​
 answer_key = []
-​
 with open(answer_key_file) as ak_csv:
-  ak_reader = csv.reader(ak_csv)
-  next(ak_reader)
-  for row in ak_reader:
-    if row[3] == '1':
-      answer_pair = [row[1], row[2]]
-      answer_pair.sort()
-      answer_key.append(answer_pair)
-​
+    ak_reader = csv.reader(ak_csv)
+    next(ak_reader)
+    for row in ak_reader:
+        if row[3] == "1":
+            answer_pair = [row[1], row[2]]
+            answer_pair.sort()
+            answer_key.append(answer_pair)
 answer_key_length = len(answer_key)
-​
 patid_csv_path = Path(c.matching_results_folder) / "patid_link_ids.csv"
-​
 with open(patid_csv_path) as patid_csv:
-  pat_id_reader = csv.reader(patid_csv)
-  next(pat_id_reader)
-  for row in pat_id_reader:
-    patids = row[1:6]
-    patids = list(filter(lambda id: len(id) > 0, patids))
-    combos = combinations(patids, 2)
-    for a, b in combos:
-      pair = [a, b]
-      pair.sort()
-      if pair in answer_key:
-        true_positives += 1
-      else:
-        false_positives += 1
-​
+    pat_id_reader = csv.reader(patid_csv)
+    next(pat_id_reader)
+    for row in pat_id_reader:
+        patids = row[1:6]
+        patids = list(filter(lambda id: len(id) > 0, patids))
+        combos = combinations(patids, 2)
+        for a, b in combos:
+            pair = [a, b]
+            pair.sort()
+            if pair in answer_key:
+                true_positives += 1
+            else:
+                false_positives += 1
 precision = true_positives / (true_positives + false_positives)
 recall = true_positives / answer_key_length
 fscore = 2 * ((precision * recall) / (precision + recall))
-​
-​
 print("Precision: {} Recall: {} F-Score: {}".format(precision, recall, fscore))
 print("Answer Key Size: {}".format(answer_key_length))
 print("Proposed pairs: {}".format(true_positives + false_positives))

--- a/tuning-files-scripts/score.py
+++ b/tuning-files-scripts/score.py
@@ -1,8 +1,9 @@
-import csv
-from pathlib import Path
-from dcctools.config import Configuration
-from itertools import combinations
 import argparse
+import csv
+from itertools import combinations
+from pathlib import Path
+
+from dcctools.config import Configuration
 
 parser = argparse.ArgumentParser(
     description="Tool for scoring individual linkage results"

--- a/tuning-files-scripts/translate.py
+++ b/tuning-files-scripts/translate.py
@@ -2,30 +2,30 @@
 
 import csv
 
-systems = ['a', 'b', 'c']
-root_path = '/Users/andrewg/projects/anonlink-multiparty/data/siblings/system-{}.csv'
+systems = ["a", "b", "c"]
+root_path = "/Users/andrewg/projects/anonlink-multiparty/data/siblings/system-{}.csv"
 
 systems_raw_data = {}
 
 for s in systems:
-  with open(root_path.format(s)) as csvfile:
-    reader = csv.DictReader(csvfile)
-    systems_raw_data[s] = list(reader)
+    with open(root_path.format(s)) as csvfile:
+        reader = csv.DictReader(csvfile)
+        systems_raw_data[s] = list(reader)
 
-with open('network_ids.csv', newline='') as source:
-  with open('translated_network_ids.csv', 'w', newline='') as output:
-    reader = csv.DictReader(source)
-    writer = csv.writer(output)
-    header = ['network_id']
-    header.extend(systems)
-    writer.writerow(header)
-    for row in reader:
-      translated_row = []
-      translated_row.append(row['network_id'])
-      for s in systems:
-        id = row[s]
-        if id == '':
-          translated_row.append('')
-        else:
-          translated_row.append(systems_raw_data[s][int(id)]['record_id'])
-      writer.writerow(translated_row)
+with open("network_ids.csv", newline="") as source:
+    with open("translated_network_ids.csv", "w", newline="") as output:
+        reader = csv.DictReader(source)
+        writer = csv.writer(output)
+        header = ["network_id"]
+        header.extend(systems)
+        writer.writerow(header)
+        for row in reader:
+            translated_row = []
+            translated_row.append(row["network_id"])
+            for s in systems:
+                id = row[s]
+                if id == "":
+                    translated_row.append("")
+                else:
+                    translated_row.append(systems_raw_data[s][int(id)]["record_id"])
+            writer.writerow(translated_row)

--- a/util/config/config_util.py
+++ b/util/config/config_util.py
@@ -1,7 +1,8 @@
-from dcctools.config import Configuration
-import util.file.file_util as fu
 import json
+
+import util.file.file_util as fu
 import util.json.json_util as ju
+from dcctools.config import Configuration
 
 
 def get_config_json_obj_from_abs_path(file_name):

--- a/util/config/config_util.py
+++ b/util/config/config_util.py
@@ -20,7 +20,9 @@ def get_config_json_obj(file_name):
         config = json.load(file)
     config["schema_folder"] = fu.get_file_name(config["schema_folder"])
     config["inbox_folder"] = fu.get_file_name(config["inbox_folder"])
-    config["matching_results_folder"] = fu.get_file_name(config["matching_results_folder"])
+    config["matching_results_folder"] = fu.get_file_name(
+        config["matching_results_folder"]
+    )
     config["output_folder"] = fu.get_file_name(config["output_folder"])
     config["blocking_schema"] = fu.get_file_name(config["blocking_schema"])
     config["household_schema"] = fu.get_file_name(config["household_schema"])
@@ -50,4 +52,3 @@ def get_config_from_string(json_string):
 
 def get_json_pretty_printed(config):
     return ju.pretty_print(config.config_json)
-

--- a/util/file/file_util.py
+++ b/util/file/file_util.py
@@ -10,6 +10,7 @@ import definitions
 #
 # ---
 
+
 # Method to get a file for the given path based on the root directory of the project
 def get_file_name(rel_path):
     return str(Path(definitions.ROOT_DIR, rel_path).resolve())
@@ -57,7 +58,7 @@ def get_files(path):
     rtn = []
     for file in files:
         cur = os.path.join(str(path), file)
-        if os.path.isdir(cur) == False:
+        if os.path.isdir(cur) is False:
             rtn.append(cur)
     return rtn
 

--- a/util/file/file_util.py
+++ b/util/file/file_util.py
@@ -1,8 +1,8 @@
 import os
 import shutil
-import definitions
 from pathlib import Path
 
+import definitions
 
 # ---
 #

--- a/util/file/file_util.py
+++ b/util/file/file_util.py
@@ -81,5 +81,3 @@ def exists(path):
 def write_string_to_file(string, file_path):
     with open(file_path, "w") as text_file:
         text_file.write(string)
-
-

--- a/util/json/json_util.py
+++ b/util/json/json_util.py
@@ -7,6 +7,3 @@ def pretty_print(json_obj):
 
 def get_str(json_object):
     return str(json.dumps(json_object))
-
-
-

--- a/util/linkage_agent/linkage_agent_util.py
+++ b/util/linkage_agent/linkage_agent_util.py
@@ -17,11 +17,14 @@ def drop(config):
     database.household_match_groups.drop()
     print("Database cleared.")
 
+
 def projects(config):
     p.run_projects(config)
 
+
 def match(config):
     m.do_match(config)
+
 
 def link_id(config):
     li.do_link_ids(config)

--- a/util/linkage_agent/linkage_agent_util.py
+++ b/util/linkage_agent/linkage_agent_util.py
@@ -1,9 +1,10 @@
 from pymongo import MongoClient
-import validate as val
-import projects as p
-import match as m
-import link_ids as li
+
 import data_owner_ids as doi
+import link_ids as li
+import match as m
+import projects as p
+import validate as val
 
 
 def validate(config):

--- a/util/linkage_agent/time_test_runner.py
+++ b/util/linkage_agent/time_test_runner.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import os
 import time

--- a/util/linkage_agent/time_test_runner.py
+++ b/util/linkage_agent/time_test_runner.py
@@ -54,8 +54,18 @@ def run_time_test(root_dir_name, patient_dirs, config):
         fu.mkdirs(current_config.matching_results_folder)
         fu.mkdirs(current_config.output_folder)
         print("Exists:")
-        print("matching_folder: " + str(fu.exists(config.matching_results_folder)) + "\t" + config.matching_results_folder)
-        print("output_folder:   " + str(fu.exists(config.output_folder)) + "\t" + config.output_folder)
+        print(
+            "matching_folder: "
+            + str(fu.exists(config.matching_results_folder))
+            + "\t"
+            + config.matching_results_folder
+        )
+        print(
+            "output_folder:   "
+            + str(fu.exists(config.output_folder))
+            + "\t"
+            + config.output_folder
+        )
         print("Config:\n" + ju.pretty_print(current_config.config_json))
         start = time.time()
         lau.generate_link_ids(current_config)
@@ -63,7 +73,9 @@ def run_time_test(root_dir_name, patient_dirs, config):
         elapsed = end - start
         msg = msg + str(elapsed) + "," + infile_dir_name + "\n"
         print(msg)
-        time_test_result_file = Path(time_test_result_dir, "time-test-results-" + infile_dir_name + ".txt")
+        time_test_result_file = Path(
+            time_test_result_dir, "time-test-results-" + infile_dir_name + ".txt"
+        )
         print("Writing results to: " + str(time_test_result_file))
         fu.write_string_to_file(msg, str(time_test_result_file))
         print("Done writing file")
@@ -79,6 +91,3 @@ def run_time_test(root_dir_name, patient_dirs, config):
     print("")
     print("")
     print("Done.")
-
-
-

--- a/util/linkage_agent/time_test_runner.py
+++ b/util/linkage_agent/time_test_runner.py
@@ -1,13 +1,13 @@
-import json
 import argparse
-from pathlib import Path
-
-import util.file.file_util as fu
-import util.config.config_util as cu
-import util.json.json_util as ju
-import util.linkage_agent.linkage_agent_util as lau
+import json
 import os
 import time
+from pathlib import Path
+
+import util.config.config_util as cu
+import util.file.file_util as fu
+import util.json.json_util as ju
+import util.linkage_agent.linkage_agent_util as lau
 
 
 def run_time_test(root_dir_name, patient_dirs, config):


### PR DESCRIPTION
- [x] Adds Black formatter, flake8 linter, and isort import sorter.
- [x] Added GitHub Action to run black, flake8, and isort.
- [x] Fixes all issues flagged by above tools



Here's the current flake8 errors caught after running black.

```
./link_ids.py:69:34: E711 comparison to None should be 'if cond is not None:'
./link_ids.py:98:38: E711 comparison to None should be 'if cond is not None:'
./link_ids.py:120:89: E501 line too long (97 > 88 characters)
./time_test.py:27:89: E501 line too long (98 > 88 characters)
./test/linkage-agent/manual/hello_world.py:1:1: F401 'test_util.linkage.run_full_linkage_test as flt' imported but unused
./util/file/file_util.py:60:31: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
./util/linkage_agent/time_test_runner.py:2:1: F401 'argparse' imported but unused
./tests/deconflict_test.py:1:1: F401 'pytest' imported but unused
./tests/anonlink_test.py:1:1: F401 'os' imported but unused
./tests/anonlink_test.py:4:1: F401 'pytest' imported but unused
./tests/config_test.py:1:1: F401 'pytest' imported but unused
./tests/config_test.py:5:1: F401 'dcctools.config.Configuration' imported but unused
./dcctools/config.py:155:21: E722 do not use bare 'except'
./dcctools/anonlink.py:1:1: F401 'itertools as it' imported but unused
./tuning-files-scripts/patid_translate.py:4:1: F401 'sys' imported but unused
```

Steps to recreate this PR:

- Install black and flake8 by adding this to `requirements.txt
```txt
black==22.3.0
flake8==4.0.1
isort==5.10.1
```
- add `.flake8` and `.isort.cfg` to make flake8, isort, and black play nice.
- run `black .`
- run `isort .`
- run `flake8 .`