### PR TITLE
Concordance Analysis Script

### DIFF
--- a/dcctools/concordance.py
+++ b/dcctools/concordance.py
@@ -1,0 +1,69 @@
+import argparse
+from itertools import combinations
+import pandas as pd
+from pathlib import Path
+
+from config import Configuration
+
+c = Configuration("config.json")
+link_id_csv_path = Path(c.matching_results_folder) / "link_ids.csv"
+link_ids = pd.read_csv(link_id_csv_path, dtype=str, index_col=0)
+
+parser = argparse.ArgumentParser(
+    description="Script for performing concordance analysis across site data"
+)
+parser.add_argument(
+    "system_data_folder",
+    help="Path to the folder containing exported system data",
+)
+args = parser.parse_args()
+
+systems = c.systems
+system_data = {}
+system_data_folder = Path(args.system_data_folder)
+
+for site in systems:
+    system_data[site] = pd.read_csv(system_data_folder / f"concord_{site}.csv", dtype=str, index_col=0).add_suffix(f"_{site}")
+
+for n in range(2, len(systems) + 1):
+    print(f"{n}-wise concordance")
+    for test_systems in combinations(systems, n):
+        print(test_systems)
+        # get the columns(systems) of interest, and drop rows containing any NA
+
+        test_data = link_ids[list(test_systems)].dropna()
+
+        print(f"Link IDs common to all {n} systems: {len(test_data)}")
+
+        if len(test_data) == 0:
+            continue
+
+        for s in test_systems:
+            test_data = test_data.merge(system_data[s], left_index=True, right_index=True)
+
+        # index (link_id) no longer useful past this point
+        test_data = test_data.reset_index()
+
+        for field in ['birth_date', 'sex']:
+            test_cols = [col for col in test_data.columns if col.startswith(field)]
+
+            data_to_compare = test_data[test_cols]
+
+            # count the number of unique values per row
+            concordance = data_to_compare.nunique(axis=1).value_counts().to_dict()
+            # a count of 1 means all columns had the same value == concordance
+            # the range of possible values is 1..n
+            # for this analysis there is no difference between 2, 3, ..., n
+
+            concordance_pct = 0
+            if 1 in concordance:
+                concordance_pct = concordance[1] / len(data_to_compare)
+
+            print(f"{field}: {concordance} --> {concordance_pct * 100.0}%")
+
+        print()
+
+    print()
+    print()
+
+

--- a/dcctools/concordance.py
+++ b/dcctools/concordance.py
@@ -1,8 +1,8 @@
 import argparse
 from itertools import combinations
-import pandas as pd
 from pathlib import Path
 
+import pandas as pd
 from config import Configuration
 
 c = Configuration("config.json")
@@ -23,7 +23,9 @@ system_data = {}
 system_data_folder = Path(args.system_data_folder)
 
 for site in systems:
-    system_data[site] = pd.read_csv(system_data_folder / f"concord_{site}.csv", dtype=str, index_col=0).add_suffix(f"_{site}")
+    system_data[site] = pd.read_csv(
+        system_data_folder / f"concord_{site}.csv", dtype=str, index_col=0
+    ).add_suffix(f"_{site}")
 
 for n in range(2, len(systems) + 1):
     print(f"{n}-wise concordance")
@@ -39,12 +41,14 @@ for n in range(2, len(systems) + 1):
             continue
 
         for s in test_systems:
-            test_data = test_data.merge(system_data[s], left_index=True, right_index=True)
+            test_data = test_data.merge(
+                system_data[s], left_index=True, right_index=True
+            )
 
         # index (link_id) no longer useful past this point
         test_data = test_data.reset_index()
 
-        for field in ['birth_date', 'sex']:
+        for field in ["birth_date", "sex"]:
             test_cols = [col for col in test_data.columns if col.startswith(field)]
 
             data_to_compare = test_data[test_cols]
@@ -65,5 +69,3 @@ for n in range(2, len(systems) + 1):
 
     print()
     print()
-
-

--- a/dcctools/concordance.py
+++ b/dcctools/concordance.py
@@ -36,6 +36,11 @@ for site in systems:
     # so we can drop duplicates on (linkid, birth_date, sex)
     site_data = site_data.drop_duplicates()
 
+    # trying to get sex values to line up.
+    # prior results showed 0% concordance so we suspect maybe trailing spaces?
+    site_data["sex"] = site_data["sex"].apply(
+        lambda x: x.strip() if isinstance(x, str) else x
+    )
     # the index isn't considered in the dup check,
     # so linkid gets set as index afterward
     # (there may be ways to optimize this)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest>=5.3.2
 requests>=2.20.0
 pymongo>=3.11.2
 tqdm>=4.36.1
+pandas>=1.2.1


### PR DESCRIPTION
This PR introduces a new script for concordance analysis - checking whether the records that were linked across sites by a LINK ID agree or disagree on the date of birth and sex fields. It's important to note that if the records disagree, that is not necessarily a false positive match, and if they agree, that is not necessarily a true positive, however in general we hope to see a high % concordance.

For a set of n sites, this loops over all combinations of sites, from size 2 to n. For each combination, it filters to just the LINK IDs that link to those sites, and counts the number of unique values it sees for the two fields of interest on each LINK ID. If there is only 1 unique value seen for a given LINK ID, that means all sites agree. Otherwise there must be 2 or more.

A full sample output of this script is attached: 
[concordance_script_sample.txt](https://github.com/mitre/linkage-agent-tools/files/8766442/concordance_script_sample.txt)

Small snippet below:
```
('site_a', 'site_b', 'site_c')
Link IDs common to all 3 sites: 370
birth_date: {3: 369, 2: 1} --> 0.0%
sex: {2: 276, 1: 68, 3: 26} --> 18.37837837837838%
```
In this example, there are 370 link ids in common between the 3 sites, for 369 of them it saw 3 unique birth_dates, and for 1 it saw 2 unique birth_dates. “Concordance” here is counted as all sites in agreement, which would be only 1 unique birth_date. For birth_date there were no instances of 1 unique value, so concordance is 0. For sex, there were 276 instances of 2 unique sex values, 68 instances of 1 unique value, 26 instances of 3 unique values. Concordance = 68/370 = 18%.


IMPORTANT: this script expects 2 important sources of data:
 - the link_ids.csv file created during the linkage agent process
 - extracts of LINK ID, date of birth, and sex from the CODI data mart from each site
It's theoretically possible to do this analysis without the link_ids.csv file, but by including it here we hopefully speed up the process.
