### PR TITLE
Performance tweaks: use explicit sessions to prevent timeouts, and allowDiskUse on mongo queries

### DIFF
--- a/dcctools/freqs_of_matching_projs.py
+++ b/dcctools/freqs_of_matching_projs.py
@@ -13,7 +13,8 @@ results = database.match_groups.aggregate(
                 "total": {"$sum": 1},
             }
         }
-    ]
+    ],
+    allowDiskUse=True,
 )
 
 for result in results:

--- a/dcctools/matching_project_shapes.py
+++ b/dcctools/matching_project_shapes.py
@@ -33,7 +33,8 @@ if version_array[0] > 4 or (version_array[0] == 4 and version_array[1] >= 4):
             },
             {"$group": {"_id": "$key", "total": {"$sum": 1}}},
             {"$sort": {"total": -1}},
-        ]
+        ],
+        allowDiskUse=True,
     )
 else:
     results = database.match_groups.aggregate(
@@ -59,7 +60,8 @@ else:
             },
             {"$group": {"_id": "$shape", "count": {"$sum": 1}}},
             {"$sort": {"count": -1}},
-        ]
+        ],
+        allowDiskUse=True,
     )
 
 

--- a/dcctools/project_matching_freq.py
+++ b/dcctools/project_matching_freq.py
@@ -10,7 +10,8 @@ results = database.match_groups.aggregate(
     [
         {"$unwind": "$run_results"},
         {"$group": {"_id": "$run_results.project", "total": {"$sum": 1}}},
-    ]
+    ],
+    allowDiskUse=True,
 )
 
 for result in results:

--- a/dcctools/project_review.py
+++ b/dcctools/project_review.py
@@ -180,7 +180,8 @@ def main():
         print(f"Total number of matches: {total}")
 
         total = database.match_groups.aggregate(
-            [{"$group": {"_id": None, "count": {"$sum": {"$size": "$run_results"}}}}]
+            [{"$group": {"_id": None, "count": {"$sum": {"$size": "$run_results"}}}}],
+            allowDiskUse=True,
         )
         for doc in total:  # should only be one result in the cursor
             count = doc["count"]

--- a/link_ids.py
+++ b/link_ids.py
@@ -72,7 +72,9 @@ def do_link_ids(c, remove=False):
                         # refresh the session if it's been more than 5 minutes
                         # https://www.mongodb.com/docs/v4.4/reference/method/cursor.noCursorTimeout/#session-idle-timeout-overrides-nocursortimeout
                         if (datetime.datetime.now() - refresh_timestamp).seconds > 300:
-                            client.admin.command({"refreshSessions": [session.session_id]})
+                            client.admin.command(
+                                {"refreshSessions": [session.session_id]}
+                            )
                             refresh_timestamp = datetime.datetime.now()
 
                         final_record = {}
@@ -106,7 +108,9 @@ def do_link_ids(c, remove=False):
                         # refresh the session if it's been more than 5 minutes
                         # https://www.mongodb.com/docs/v4.4/reference/method/cursor.noCursorTimeout/#session-idle-timeout-overrides-nocursortimeout
                         if (datetime.datetime.now() - refresh_timestamp).seconds > 300:
-                            client.admin.command({"refreshSessions": [session.session_id]})
+                            client.admin.command(
+                                {"refreshSessions": [session.session_id]}
+                            )
                             refresh_timestamp = datetime.datetime.now()
 
                         conflict = reduce(

--- a/link_ids.py
+++ b/link_ids.py
@@ -87,7 +87,6 @@ def do_link_ids(c, remove=False):
             writer = csv.DictWriter(csvfile, fieldnames=header)
             writer.writeheader()
             with client.start_session(causal_consistency=True) as session:
-                session_id = session.session_id["id"]
                 with database.match_groups.find(
                     session=session, no_cursor_timeout=True
                 ) as cursor:
@@ -96,7 +95,7 @@ def do_link_ids(c, remove=False):
                         # refresh the session if it's been more than 5 minutes
                         # https://www.mongodb.com/docs/v4.4/reference/method/cursor.noCursorTimeout/#session-idle-timeout-overrides-nocursortimeout
                         if (datetime.datetime.now() - refresh_timestamp).seconds > 300:
-                            client.admin.command({"refreshSessions": [session_id]})
+                            client.admin.command({"refreshSessions": [session.session_id]})
                             refresh_timestamp = datetime.datetime.now()
 
                         conflict = reduce(


### PR DESCRIPTION
This PR addresses 2 issues identified when running our scripts at scale:

 -  We've seen an issue where users get "cursor not found" errors when the link_ids script runs for a long time. We thought we fixed it by setting no_cursor_timeout=True, but apparently that's not a 100% solution.
The suggested solution is to use an explicit session and refresh it at regular intervals to ensure the cursor and session don't time out. This has appeared to resolve the issue in testing.

```
  File "/home/ubuntu/linkage-agent-tools/link_ids.py", line 88, in do_link_ids
    for row in database.match_groups.find(no_cursor_timeout=True):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/cursor.py", line 1248, in next
    if len(self.__data) or self._refresh():
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/cursor.py", line 1188, in _refresh
    self.__send_message(g)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/cursor.py", line 1052, in __send_message
    response = client._run_operation(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1267, in _run_operation
    return self._retryable_read(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1371, in _retryable_read
    return func(session, server, sock_info, read_pref)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1263, in _cmd
    return server.run_operation(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/server.py", line 134, in run_operation
    _check_command_response(first, sock_info.max_wire_version)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/helpers.py", line 178, in _check_command_response
    raise CursorNotFound(errmsg, code, response, max_wire_version)
pymongo.errors.CursorNotFound: cursor id 64559458270 not found, full error: {'ok': 0.0, 'errmsg': 'cursor id 64559458270 not found', 'code': 43, 'codeName': 'CursorNotFound'}
```

- Certain QA scripts fail due to memory usage issues. The quick fix is to add "allowDiskUse = True" to the mongo aggregations. I've added it here to all of the aggregations for consistency, even though it's probably not required in practice for all of them.
```
Traceback (most recent call last):
  File "./dcctools/matching_project_shapes.py", line 39, in <module>
    results = database.match_groups.aggregate(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/collection.py", line 2402, in aggregate
    return self._aggregate(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/collection.py", line 2309, in _aggregate
    return self.__database.client._retryable_read(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1371, in _retryable_read
    return func(session, server, sock_info, read_pref)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/aggregation.py", line 140, in get_cursor
    result = sock_info.command(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/pool.py", line 743, in command
    return command(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/network.py", line 160, in command
    helpers._check_command_response(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pymongo/helpers.py", line 180, in _check_command_response
    raise OperationFailure(errmsg, code, response, max_wire_version)
pymongo.errors.OperationFailure: Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting. Aborting operation. Pass allowDiskUse:true to opt in., full error: {'ok': 0.0, 'errmsg': 'Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting. Aborting operation. Pass allowDiskUse:true to opt in.', 'code': 16819, 'codeName': 'Location16819'}
```