### PR TITLE
Timestamp Standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,14 @@ python -m venv venv/
 source venv/bin/activate
 ```
 
-#### Installing dependencies
+#### Installing package and dependencies
 
 ```shell
 pip install -r requirements.txt
+pip install -e .
 ```
+
+The second invocation of `pip` is required in order for `setup.py` to be able to communicate with your local installation of python so that the included modules can be found easily.
 
 ### Installing with Anaconda
 
@@ -103,6 +106,7 @@ pip install -r requirements.txt
    1. `conda activate codi`
    1. `conda install pip`
    1. `pip install -r requirements.txt`
+   1. `pip install -e .`
 
 ## Configuration
 

--- a/data_owner_ids.py
+++ b/data_owner_ids.py
@@ -101,9 +101,10 @@ def do_data_owner_ids(c):
     if len(link_ids) > 1:
         ts_len = len(datetime.now().strftime(TIMESTAMP_FMT))
         # -4 since ".csv" is 4 chars
-        ts_loc = (-(4+ts_len), -4)
+        ts_loc = (-(4 + ts_len), -4)
         link_id_times = [
-            datetime.strptime(x.name[ts_loc[0]:ts_loc[1]], TIMESTAMP_FMT) for x in link_ids
+            datetime.strptime(x.name[ts_loc[0] : ts_loc[1]], TIMESTAMP_FMT)
+            for x in link_ids
         ]
         most_recent = link_ids[link_id_times.index(max(link_id_times))]
         print(f"Using most recent link_id file: {most_recent}")

--- a/data_owner_ids.py
+++ b/data_owner_ids.py
@@ -97,12 +97,13 @@ def do_data_owner_ids(c):
         )
     else:
         link_ids = sorted(Path(c.matching_results_folder).glob("link_ids*.csv"))
-
+    print("link_ids", link_ids)
     if len(link_ids) > 1:
-        print("More than one link_id file found")
-        print(link_ids)
+        ts_len = len(datetime.now().strftime(TIMESTAMP_FMT))
+        # -4 since ".csv" is 4 chars
+        ts_loc = (-(4+ts_len), -4)
         link_id_times = [
-            datetime.strptime(x.name[-19:-4], TIMESTAMP_FMT) for x in link_ids
+            datetime.strptime(x.name[ts_loc[0]:ts_loc[1]], TIMESTAMP_FMT) for x in link_ids
         ]
         most_recent = link_ids[link_id_times.index(max(link_id_times))]
         print(f"Using most recent link_id file: {most_recent}")

--- a/data_owner_ids.py
+++ b/data_owner_ids.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 
 from dcctools.config import Configuration
+from definitions import TIMESTAMP_FMT
 
 
 def parse_args():
@@ -52,7 +53,7 @@ def zip_and_clean(system_output_path, system, timestamp, household_match):
 
 def process_output(link_id_path, output_path, system, metadata, household_match):
     data_owner_id_time = datetime.now()
-    timestamp = data_owner_id_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = data_owner_id_time.strftime(TIMESTAMP_FMT)
     n_rows = 0
     with open(link_id_path) as csvfile:
         reader = csv.DictReader(csvfile)
@@ -101,7 +102,7 @@ def do_data_owner_ids(c):
         print("More than one link_id file found")
         print(link_ids)
         link_id_times = [
-            datetime.strptime(x.name[-19:-4], "%Y%m%dT%H%M%S") for x in link_ids
+            datetime.strptime(x.name[-19:-4], TIMESTAMP_FMT) for x in link_ids
         ]
         most_recent = link_ids[link_id_times.index(max(link_id_times))]
         print(f"Using most recent link_id file: {most_recent}")

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -182,15 +182,20 @@ class Configuration:
         return clk_path
 
     def get_clks_raw(self, system, project):
-        clks = None
         clk_zip_path = Path(self.config_json["inbox_folder"]) / "{}.zip".format(system)
         with ZipFile(clk_zip_path, mode="r") as clk_zip:
+            project_file = None
             for file_name in clk_zip.namelist():
                 if f"{project}.json" in file_name:
                     project_file = file_name
                     break
-            with clk_zip.open(project_file) as clk_file:
-                clks = clk_file.read()
+            if project_file is not None:
+                with clk_zip.open(project_file) as clk_file:
+                    clks = clk_file.read()
+            else:
+                raise KeyError(
+                    f"There is no item named '{project}.json' in the archive {system}.zip"
+                )
         return clks
 
     def get_household_clks_raw(self, system, schema):

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -194,7 +194,8 @@ class Configuration:
                     clks = clk_file.read()
             else:
                 raise KeyError(
-                    f"There is no item named '{project}.json' in the archive {system}.zip"
+                    f"There is no item named '{project}.json' "
+                    f"in the archive {system}.zip"
                 )
         return clks
 

--- a/dcctools/config.py
+++ b/dcctools/config.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zipfile import ZipFile
 
+from definitions import TIMESTAMP_FMT
+
 
 class Configuration:
     def __init__(self, filename):
@@ -52,7 +54,7 @@ class Configuration:
                     metadata_files.append(fname)
                     anchor = fname.rfind("T")
                     mname = fname[(anchor - 8) : (anchor + 7)]
-                    timestamp = datetime.strptime(mname, "%Y%m%dT%H%M%S")
+                    timestamp = datetime.strptime(mname, TIMESTAMP_FMT)
                     with archive.open(fname, "r") as metadata_fp:
                         metadata = json.load(metadata_fp)
                     garble_time = datetime.fromisoformat(metadata["creation_date"])

--- a/definitions.py
+++ b/definitions.py
@@ -3,4 +3,3 @@ import os
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 TIMESTAMP_FMT = "%Y%m%dT%H%M%S"
-

--- a/definitions.py
+++ b/definitions.py
@@ -1,3 +1,6 @@
 import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+TIMESTAMP_FMT = "%Y%m%dT%H%M%S"
+

--- a/link_ids.py
+++ b/link_ids.py
@@ -12,6 +12,7 @@ from pymongo import MongoClient
 
 from dcctools.config import Configuration
 from dcctools.deconflict import deconflict
+from definitions import TIMESTAMP_FMT
 
 
 def parse_args():
@@ -35,7 +36,7 @@ def parse_args():
 
 def do_link_ids(c, remove=False):
     link_id_time = datetime.datetime.now()
-    timestamp = datetime.datetime.strftime(link_id_time, "%Y%m%dT%H%M%S")
+    timestamp = datetime.datetime.strftime(link_id_time, TIMESTAMP_FMT)
     n_records = 0
 
     client = MongoClient(c.mongo_uri)

--- a/match.py
+++ b/match.py
@@ -11,6 +11,7 @@ from pymongo import MongoClient
 
 from dcctools.anonlink import Results
 from dcctools.config import Configuration
+from definitions import TIMESTAMP_FMT
 
 # Delay between run status checks
 SLEEP_TIME = 10.0
@@ -89,7 +90,7 @@ def do_matching(config, projects, collection):
             }
             results = Results(config.systems, project_name, result_json)
             results.insert_results(collection)
-    timestamp = match_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = match_time.strftime(TIMESTAMP_FMT)
     with open(
         Path(config.project_results_dir) / f"match-metadata-{timestamp}.json", "w+"
     ) as metadata_file:

--- a/projects.py
+++ b/projects.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from dcctools.anonlink import Project
 from dcctools.config import Configuration
+from definitions import TIMESTAMP_FMT
 
 # Delay between run status checks
 SLEEP_TIME = 10.0
@@ -33,7 +34,7 @@ def parse_args():
 
 def run_projects(c, project_name=None):
     projects_start_time = datetime.datetime.now()
-    timestamp = projects_start_time.strftime("%y%m%d")
+    timestamp = projects_start_time.strftime(TIMESTAMP_FMT)
     with open(
         Path(c.project_results_dir) / f"project-metadata-{timestamp}.json", "w+"
     ) as metadata_file:
@@ -100,7 +101,7 @@ def run_project(c, metadata_timestamp, project_name=None, households=False):
     result_json = project.get_results()
     metadata[project_name]["completion_time"] = datetime.datetime.now().isoformat()
     metadata[project_name]["number_of_groups"] = len(result_json.get("groups", []))
-    timestamp = project_start_time.strftime("%y%m%d")
+    timestamp = project_start_time.strftime(TIMESTAMP_FMT)
     Path(c.project_results_dir).mkdir(parents=True, exist_ok=True)
     with open(
         Path(c.project_results_dir) / f"{project_name}-{timestamp}.json", "w"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup, find_packages
+
+setup(name='linkage-agent-tools', version='0.0', packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-setup(name='linkage-agent-tools', version='0.0', packages=find_packages())
+setup(name="linkage-agent-tools", version="0.0", packages=find_packages())


### PR DESCRIPTION
Standardized the timestamp format used in canonical file naming by adding a line to `definitions.py` that defines it. This changes the timestamp used in a few places (namely the files created by `projects.py`) and if we choose to change the time stamp convention doing so will be much simpler.

see sister PR [data-owner-tools#46](https://github.com/mitre/data-owner-tools/pull/46)

In completion of [ticket #183428340](https://www.pivotaltracker.com/story/show/183428340)