### PR TITLE
New qa script for a quick count of links between data owners

### DIFF
--- a/dcctools/link_count.py
+++ b/dcctools/link_count.py
@@ -1,0 +1,47 @@
+import datetime
+from itertools import combinations
+from pathlib import Path
+
+import pandas as pd
+from config import Configuration
+
+from definitions import TIMESTAMP_FMT
+
+
+c = Configuration("config.json")
+
+if c.household_match:
+    link_ids = sorted(
+        Path(c.matching_results_folder).glob("household_link_ids*.csv")
+    )
+else:
+    link_ids = sorted(Path(c.matching_results_folder).glob("link_ids*.csv"))
+
+if len(link_ids) > 1:
+    ts_len = len(datetime.now().strftime(TIMESTAMP_FMT))
+    # -4 since ".csv" is 4 chars
+    ts_loc = (-(4 + ts_len), -4)
+    link_id_times = [
+        datetime.strptime(x.name[ts_loc[0] : ts_loc[1]], TIMESTAMP_FMT)
+        for x in link_ids
+    ]
+    most_recent = link_ids[link_id_times.index(max(link_id_times))]
+    print(f"Using most recent link_id file: {most_recent}")
+
+    link_id_path = most_recent
+else:
+    link_id_path = link_ids[0]
+
+link_ids = pd.read_csv(link_id_path, dtype=str, index_col=0)
+
+systems = c.systems
+system_data = {}
+
+for n in range(2, len(systems) + 1):
+    print(f"=== {n}-wise links ===")
+    for test_systems in combinations(systems, n):
+        # get the columns(systems) of interest, and drop rows containing any NA
+        test_data = link_ids[list(test_systems)].dropna()
+        print(f"{test_systems}: {len(test_data)} Link IDs")
+
+    print()


### PR DESCRIPTION
Adds a new QA script: `link_count.py`, just intended to report out a basic count of the number of links between all combinations of data owners. This will quickly show if one or more sites are not matching at the frequency expected.
The code is basically just the first half of the existing concordance.py script

Sample output:
```
$ py dcctools/link_count.py
=== 2-wise links ===
('site_a', 'site_b'): 214 Link IDs
('site_a', 'site_c'): 126 Link IDs
('site_a', 'site_d'): 105 Link IDs
('site_a', 'site_e'): 120 Link IDs
('site_a', 'site_f'): 205 Link IDs
('site_b', 'site_c'): 213 Link IDs
('site_b', 'site_d'): 150 Link IDs
('site_b', 'site_e'): 88 Link IDs
('site_b', 'site_f'): 117 Link IDs
('site_c', 'site_d'): 213 Link IDs
('site_c', 'site_e'): 130 Link IDs
('site_c', 'site_f'): 85 Link IDs
('site_d', 'site_e'): 198 Link IDs
('site_d', 'site_f'): 146 Link IDs
('site_e', 'site_f'): 197 Link IDs

=== 3-wise links ===
('site_a', 'site_b', 'site_c'): 49 Link IDs
('site_a', 'site_b', 'site_d'): 27 Link IDs
('site_a', 'site_b', 'site_e'): 20 Link IDs
('site_a', 'site_b', 'site_f'): 38 Link IDs
('site_a', 'site_c', 'site_d'): 20 Link IDs
('site_a', 'site_c', 'site_e'): 14 Link IDs
('site_a', 'site_c', 'site_f'): 21 Link IDs
('site_a', 'site_d', 'site_e'): 22 Link IDs
('site_a', 'site_d', 'site_f'): 27 Link IDs
('site_a', 'site_e', 'site_f'): 41 Link IDs
('site_b', 'site_c', 'site_d'): 52 Link IDs
('site_b', 'site_c', 'site_e'): 24 Link IDs
('site_b', 'site_c', 'site_f'): 22 Link IDs
('site_b', 'site_d', 'site_e'): 27 Link IDs
('site_b', 'site_d', 'site_f'): 19 Link IDs
('site_b', 'site_e', 'site_f'): 25 Link IDs
('site_c', 'site_d', 'site_e'): 38 Link IDs
('site_c', 'site_d', 'site_f'): 24 Link IDs
('site_c', 'site_e', 'site_f'): 24 Link IDs
('site_d', 'site_e', 'site_f'): 50 Link IDs

=== 4-wise links ===
('site_a', 'site_b', 'site_c', 'site_d'): 5 Link IDs
('site_a', 'site_b', 'site_c', 'site_e'): 6 Link IDs
('site_a', 'site_b', 'site_c', 'site_f'): 5 Link IDs
('site_a', 'site_b', 'site_d', 'site_e'): 5 Link IDs
('site_a', 'site_b', 'site_d', 'site_f'): 4 Link IDs
('site_a', 'site_b', 'site_e', 'site_f'): 5 Link IDs
('site_a', 'site_c', 'site_d', 'site_e'): 3 Link IDs
('site_a', 'site_c', 'site_d', 'site_f'): 4 Link IDs
('site_a', 'site_c', 'site_e', 'site_f'): 4 Link IDs
('site_a', 'site_d', 'site_e', 'site_f'): 8 Link IDs
('site_b', 'site_c', 'site_d', 'site_e'): 11 Link IDs
('site_b', 'site_c', 'site_d', 'site_f'): 8 Link IDs
('site_b', 'site_c', 'site_e', 'site_f'): 8 Link IDs
('site_b', 'site_d', 'site_e', 'site_f'): 9 Link IDs
('site_c', 'site_d', 'site_e', 'site_f'): 10 Link IDs

=== 5-wise links ===
('site_a', 'site_b', 'site_c', 'site_d', 'site_e'): 2 Link IDs
('site_a', 'site_b', 'site_c', 'site_d', 'site_f'): 1 Link IDs
('site_a', 'site_b', 'site_c', 'site_e', 'site_f'): 2 Link IDs
('site_a', 'site_b', 'site_d', 'site_e', 'site_f'): 1 Link IDs
('site_a', 'site_c', 'site_d', 'site_e', 'site_f'): 2 Link IDs
('site_b', 'site_c', 'site_d', 'site_e', 'site_f'): 5 Link IDs

=== 6-wise links ===
('site_a', 'site_b', 'site_c', 'site_d', 'site_e', 'site_f'): 1 Link IDs
```